### PR TITLE
Replace coordinates with last updated date

### DIFF
--- a/CarlWeathers/Models/CWCurrentConditions.h
+++ b/CarlWeathers/Models/CWCurrentConditions.h
@@ -9,6 +9,7 @@
 @property (nonatomic, readonly) CGFloat windSpeed;
 @property (nonatomic, readonly) CGFloat windBearing;
 @property (nonatomic, readonly) CGFloat precipitationProbability;
+@property (nonatomic, readonly) NSDate *date;
 
 + (instancetype)currentConditionsFromJSON:(NSDictionary *)JSON;
 

--- a/CarlWeathers/Models/CWCurrentConditions.m
+++ b/CarlWeathers/Models/CWCurrentConditions.m
@@ -11,6 +11,7 @@
 @property (nonatomic, readwrite) CGFloat windSpeed;
 @property (nonatomic, readwrite) CGFloat windBearing;
 @property (nonatomic, readwrite) CGFloat precipitationProbability;
+@property (nonatomic, readwrite) NSDate *date;
 
 @end
 
@@ -28,6 +29,7 @@
     conditions.precipitationProbability = [JSON[@"currently"][@"precipitationProbability"] floatValue];
     conditions.windSpeed = [JSON[@"currently"][@"windSpeed"] floatValue];
     conditions.windBearing = [JSON[@"currently"][@"windBearing"] floatValue];
+    conditions.date = [NSDate date];
 
     return conditions;
 }

--- a/CarlWeathers/ViewControllers/CWWeatherViewController.m
+++ b/CarlWeathers/ViewControllers/CWWeatherViewController.m
@@ -9,7 +9,7 @@
 @property (nonatomic) CWWeatherController *controller;
 
 @property (weak, nonatomic) IBOutlet UILabel *cityLabel;
-@property (weak, nonatomic) IBOutlet UILabel *coordinateLabel;
+@property (weak, nonatomic) IBOutlet UILabel *lastUpdatedLabel;
 @property (weak, nonatomic) IBOutlet UIImageView *conditionsImageView;
 @property (weak, nonatomic) IBOutlet UILabel *conditionsDescriptionLabel;
 @property (weak, nonatomic) IBOutlet UILabel *windSpeedLabel;
@@ -54,7 +54,7 @@
 - (void)controllerDidChange:(NSDictionary *)changes object:(CWWeatherController *)controller
 {
     self.cityLabel.text = controller.viewModel.locationName;
-    self.coordinateLabel.text = controller.viewModel.formattedCoordinate;
+    self.lastUpdatedLabel.text = controller.viewModel.formattedDate;
     self.conditionsImageView.image = controller.viewModel.conditionsImage;
     self.highLowTemperatureLabel.text = controller.viewModel.formattedTemperatureRange;
     self.windSpeedLabel.text = controller.viewModel.formattedWindSpeed;

--- a/CarlWeathers/ViewModels/CWWeatherViewModel.h
+++ b/CarlWeathers/ViewModels/CWWeatherViewModel.h
@@ -5,7 +5,7 @@
 @interface CWWeatherViewModel : NSObject
 
 @property (nonatomic, copy, readonly) NSString *locationName;
-@property (nonatomic, copy, readonly) NSString *formattedCoordinate;
+@property (nonatomic, copy, readonly) NSString *formattedDate;
 @property (nonatomic, readonly) UIImage *conditionsImage;
 @property (nonatomic, copy, readonly) NSString *formattedTemperatureRange;
 @property (nonatomic, copy, readonly) NSString *formattedWindSpeed;

--- a/CarlWeathers/ViewModels/CWWeatherViewModel.m
+++ b/CarlWeathers/ViewModels/CWWeatherViewModel.m
@@ -28,7 +28,6 @@
     self.yesterdaysConditions = yesterdaysConditions;
 
     self.locationFormatter = [TTTLocationFormatter new];
-    self.locationFormatter.coordinateStyle = TTTDegreesMinutesSecondsFormat;
     self.locationFormatter.bearingStyle = TTTBearingAbbreviationWordStyle;
 
     return self;
@@ -41,9 +40,13 @@
     return [NSString stringWithFormat:@"%@, %@", self.weatherLocation.city, self.weatherLocation.state];
 }
 
-- (NSString *)formattedCoordinate
+- (NSString *)formattedDate
 {
-    return [self.locationFormatter stringFromCoordinate:self.weatherLocation.coordinate];
+    NSDateFormatter *dateFormatter = [NSDateFormatter new];
+    dateFormatter.dateStyle = NSDateFormatterShortStyle;
+    dateFormatter.timeStyle = NSDateFormatterShortStyle;
+    NSString *formattedDate = [dateFormatter stringFromDate:self.currentConditions.date];
+    return [NSString stringWithFormat:@"Last updated: %@", formattedDate];
 }
 
 - (UIImage *)conditionsImage

--- a/Resources/Storyboards/Main.storyboard
+++ b/Resources/Storyboards/Main.storyboard
@@ -33,7 +33,7 @@
                                 <color key="textColor" red="0.6705882352941176" green="0.65490196078431373" blue="0.69411764705882351" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bahstahn" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hox-Oh-26Y" userLabel="Coordinate Label">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bahstahn" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hox-Oh-26Y" userLabel="Last Updated Label">
                                 <rect key="frame" x="16" y="54" width="568" height="15"/>
                                 <fontDescription key="fontDescription" name="DINNextLTPro-UltraLight" family="DIN Next LT Pro" pointSize="15"/>
                                 <color key="textColor" red="0.56496596336364746" green="0.56460165977478027" blue="0.5951998233795166" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -138,8 +138,8 @@
                         <outlet property="cityLabel" destination="Wl8-8h-ogo" id="Oea-1a-bou"/>
                         <outlet property="conditionsDescriptionLabel" destination="4aa-2F-UFk" id="MEw-Cw-h9c"/>
                         <outlet property="conditionsImageView" destination="Ef5-IL-xEe" id="mhx-To-Xjj"/>
-                        <outlet property="coordinateLabel" destination="hox-Oh-26Y" id="f4r-wu-YdZ"/>
                         <outlet property="highLowTemperatureLabel" destination="jm9-4j-cuq" id="2Dc-yH-4sR"/>
+                        <outlet property="lastUpdatedLabel" destination="hox-Oh-26Y" id="LOY-rP-Hs3"/>
                         <outlet property="precipitationMeterView" destination="UuN-Av-FMW" id="XMO-RM-PXu"/>
                         <outlet property="temperatureImageView" destination="wxI-GT-UQg" id="OvJ-DJ-oNa"/>
                         <outlet property="windSpeedImageView" destination="Qna-Fn-Mlz" id="LM6-40-9KT"/>


### PR DESCRIPTION
I'm proposing that we replace the coordinates with the timestamp of the currently visible forecast. The coordinates aren't particularly useful or actionable and the timestamp will be more helpful once we allow manual refreshing.
