### PR TITLE
Display relative dates

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,7 @@
 platform :ios, '8.0'
 
 pod 'KVOController'
+pod 'ReactiveCocoa'
 
 target :unit_tests, :exclusive => true do
   link_with 'UnitTests'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,6 +5,13 @@ PODS:
   - OHHTTPStubs (3.1.10):
     - OHHTTPStubs/Core (= 3.1.10)
   - OHHTTPStubs/Core (3.1.10)
+  - ReactiveCocoa (2.4.4):
+    - ReactiveCocoa/UI (= 2.4.4)
+  - ReactiveCocoa/Core (2.4.4):
+    - ReactiveCocoa/no-arc
+  - ReactiveCocoa/no-arc (2.4.4)
+  - ReactiveCocoa/UI (2.4.4):
+    - ReactiveCocoa/Core
   - Specta (0.3.0.beta1)
 
 DEPENDENCIES:
@@ -12,6 +19,7 @@ DEPENDENCIES:
   - KVOController
   - OCMock
   - OHHTTPStubs
+  - ReactiveCocoa
   - Specta (from `https://github.com/specta/specta.git`, tag `v0.3.0.beta1`)
 
 EXTERNAL SOURCES:
@@ -29,6 +37,7 @@ SPEC CHECKSUMS:
   KVOController: b1139ef1fc373b6757e4b69493fedd7b56eb1272
   OCMock: ecdd510b73ef397f2f97274785c1e87fd147c49f
   OHHTTPStubs: 2038e929b6abb94881000524c1cb4aba0a1bb4a2
+  ReactiveCocoa: 31119068e3dde866bd257cf74e1f06b4023bf387
   Specta: 63e8ac8e07db6675c7096d37f77a266a1be4c02d
 
 COCOAPODS: 0.35.0

--- a/Resources/Other-Sources/Tropos-Prefix.pch
+++ b/Resources/Other-Sources/Tropos-Prefix.pch
@@ -15,4 +15,5 @@
     #import "UIFont+TRAppFonts.h"
 
     #import <KVOController/FBKVOController.h>
+    #import <ReactiveCocoa/ReactiveCocoa.h>
 #endif

--- a/Tropos.xcodeproj/project.pbxproj
+++ b/Tropos.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		4D7CDEC81A47E0500038DD33 /* UIFont+TRAppFonts.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D7CDEC71A47E0500038DD33 /* UIFont+TRAppFonts.m */; };
 		4D7CDECC1A47E13F0038DD33 /* TRTemperatureComparisonFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D7CDECB1A47E13F0038DD33 /* TRTemperatureComparisonFormatter.m */; };
 		4D7F0EEF1A3E8439008A6E1C /* TRWeatherController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D7F0EEE1A3E8439008A6E1C /* TRWeatherController.m */; };
+		4D9315201A6F44EB00CE95B3 /* TRDateFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D93151F1A6F44EB00CE95B3 /* TRDateFormatter.m */; };
 		4D9CA35D1A5C7672009E24DD /* TRBearingFormatterSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D9CA35C1A5C7672009E24DD /* TRBearingFormatterSpec.m */; };
 		4D9CA35F1A5CABDD009E24DD /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 4D9CA35E1A5CABDD009E24DD /* Settings.bundle */; };
 		4D9CA3621A5CB544009E24DD /* TRSettingsController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D9CA3611A5CB544009E24DD /* TRSettingsController.m */; };
@@ -99,6 +100,8 @@
 		4D7CDECB1A47E13F0038DD33 /* TRTemperatureComparisonFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRTemperatureComparisonFormatter.m; sourceTree = "<group>"; };
 		4D7F0EED1A3E8439008A6E1C /* TRWeatherController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TRWeatherController.h; sourceTree = "<group>"; };
 		4D7F0EEE1A3E8439008A6E1C /* TRWeatherController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRWeatherController.m; sourceTree = "<group>"; };
+		4D93151E1A6F44EB00CE95B3 /* TRDateFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TRDateFormatter.h; sourceTree = "<group>"; };
+		4D93151F1A6F44EB00CE95B3 /* TRDateFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRDateFormatter.m; sourceTree = "<group>"; };
 		4D9CA35C1A5C7672009E24DD /* TRBearingFormatterSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRBearingFormatterSpec.m; sourceTree = "<group>"; };
 		4D9CA35E1A5CABDD009E24DD /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		4D9CA3601A5CB544009E24DD /* TRSettingsController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TRSettingsController.h; sourceTree = "<group>"; };
@@ -230,6 +233,8 @@
 				4DF5BA381A5B64630088F35F /* TRBearingFormatter.m */,
 				4D3386FD1A5D27260087B88F /* TRTemperatureFormatter.h */,
 				4D3386FE1A5D27260087B88F /* TRTemperatureFormatter.m */,
+				4D93151E1A6F44EB00CE95B3 /* TRDateFormatter.h */,
+				4D93151F1A6F44EB00CE95B3 /* TRDateFormatter.m */,
 			);
 			path = Formatters;
 			sourceTree = "<group>";
@@ -616,6 +621,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4D9315201A6F44EB00CE95B3 /* TRDateFormatter.m in Sources */,
 				4D9CA3621A5CB544009E24DD /* TRSettingsController.m in Sources */,
 				4D0A5C381A3A27510084C41E /* TRForecastClient.m in Sources */,
 				C2E44CEF1A3B6E89009CC844 /* NSDate+TRRelativeDate.m in Sources */,

--- a/Tropos/Controllers/TRWeatherController.h
+++ b/Tropos/Controllers/TRWeatherController.h
@@ -1,8 +1,9 @@
-@class TRWeatherViewModel, TRWeatherStatusViewModel;
+@class TRWeatherViewModel;
 
 @interface TRWeatherController : NSObject
 
-@property (nonatomic, readonly) TRWeatherStatusViewModel *statusViewModel;
+@property (nonatomic, readonly) RACSignal *locationName;
+@property (nonatomic, readonly) RACSignal *status;
 @property (nonatomic, readonly) TRWeatherViewModel *weatherViewModel;
 
 - (void)updateWeather;

--- a/Tropos/Controllers/TRWeatherController.m
+++ b/Tropos/Controllers/TRWeatherController.m
@@ -5,18 +5,27 @@
 #import "TRWeatherViewModel.h"
 #import "TRWeatherLocation.h"
 #import "TRSettingsController.h"
-#import "TRWeatherStatusViewModel.h"
+#import "TRDateFormatter.h"
+
+typedef NS_ENUM(NSUInteger, TRWeatherUpdateStatus) {
+    TRWeatherUpdateStatusUpdating,
+    TRWeatherUpdateStatusFinished,
+    TRWeatherUpdateStatusFailed
+};
 
 @interface TRWeatherController ()
 
-@property (nonatomic, readwrite) TRWeatherStatusViewModel *statusViewModel;
 @property (nonatomic, readwrite) TRWeatherViewModel *weatherViewModel;
+
 @property (nonatomic) TRLocationController *locationController;
 @property (nonatomic) TRForecastClient *forecastClient;
+@property (nonatomic) TRDateFormatter *dateFormatter;
 
 @property (nonatomic) TRWeatherLocation *weatherLocation;
 @property (nonatomic) TRCurrentConditions *currentConditions;
 @property (nonatomic) TRHistoricalConditions *yesterdaysConditions;
+@property (nonatomic) TRWeatherUpdateStatus updateStatus;
+@property (nonatomic) NSDate *lastUpdatedDate;
 
 @end
 
@@ -34,7 +43,9 @@
             [self updateWeather];
         }
     }];
+
     self.forecastClient = [TRForecastClient new];
+    self.dateFormatter = [TRDateFormatter new];
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(unitSettingsDidChange:) name:TRSettingsDidChangeNotification object:nil];
 
@@ -48,6 +59,24 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self name:NSUserDefaultsDidChangeNotification object:nil];
 }
 
+#pragma mark - Properties
+
+- (RACSignal *)status
+{
+    RACSignal *interval = [RACSignal interval:1 onScheduler:[RACScheduler mainThreadScheduler]];
+
+    return [[RACSignal combineLatest:@[interval, RACObserve(self, updateStatus), RACObserve(self, lastUpdatedDate)] reduce:^id(id _, NSNumber *updateStatus, NSDate *date) {
+        return [self statusStringForUpdateStatus:updateStatus.unsignedIntegerValue lastUpdatedDate:date];
+    }] distinctUntilChanged];
+}
+
+- (RACSignal *)locationName
+{
+    return [RACObserve(self, weatherLocation) map:^id(TRWeatherLocation *weatherLocation) {
+        return [NSString stringWithFormat:@"%@, %@", weatherLocation.city, weatherLocation.state];
+    }];
+}
+
 #pragma mark - Public Methods
 
 - (void)updateWeather
@@ -57,17 +86,16 @@
         return;
     }
 
-    [self locationUpdateWillStart];
+    self.updateStatus = TRWeatherUpdateStatusUpdating;
 
     __weak typeof(self) weakSelf = self;
     [self.locationController updateLocationWithBlock:^(TRWeatherLocation *weatherLocation, NSError *error) {
         if (error) {
-            [self updateDidFail];
+            self.updateStatus = TRWeatherUpdateStatusFailed;
             return;
         }
 
         weakSelf.weatherLocation = weatherLocation;
-        [self conditionsUpdateWillStart];
 
         [self.forecastClient fetchConditionsAtLatitude:weatherLocation.coordinate.latitude longitude:weatherLocation.coordinate.longitude completion:^(TRCurrentConditions *currentConditions, TRHistoricalConditions *yesterdaysConditions) {
             typeof(self) strongSelf = weakSelf;
@@ -75,8 +103,8 @@
             strongSelf.currentConditions = currentConditions;
             strongSelf.yesterdaysConditions = yesterdaysConditions;
             strongSelf.weatherViewModel = [[TRWeatherViewModel alloc] initWithCurrentConditions:self.currentConditions yesterdaysConditions:self.yesterdaysConditions];
-
-            [strongSelf updateDidFinish];
+            strongSelf.lastUpdatedDate = [NSDate date];
+            strongSelf.updateStatus = TRWeatherUpdateStatusFinished;
         }];
     }];
 }
@@ -88,24 +116,16 @@
     self.weatherViewModel = [[TRWeatherViewModel alloc] initWithCurrentConditions:self.currentConditions yesterdaysConditions:self.yesterdaysConditions];
 }
 
-- (void)locationUpdateWillStart
+- (NSString *)statusStringForUpdateStatus:(TRWeatherUpdateStatus)status lastUpdatedDate:(NSDate *)date
 {
-    self.statusViewModel = [TRWeatherStatusViewModel viewModelForStatus:TRWeatherStatusLocating weatherLocation:self.weatherLocation];
-}
-
-- (void)conditionsUpdateWillStart
-{
-    self.statusViewModel = [TRWeatherStatusViewModel viewModelForStatus:TRWeatherStatusUpdating weatherLocation:self.weatherLocation];
-}
-
-- (void)updateDidFinish
-{
-    self.statusViewModel = [TRWeatherStatusViewModel viewModelForStatus:TRWeatherStatusUpdated weatherLocation:self.weatherLocation];
-}
-
-- (void)updateDidFail
-{
-    self.statusViewModel = [TRWeatherStatusViewModel viewModelForStatus:TRWeatherStatusFailed weatherLocation:self.weatherLocation];
+    switch (status) {
+        case TRWeatherUpdateStatusUpdating:
+            return NSLocalizedString(@"Updating", nil);
+        case TRWeatherUpdateStatusFinished:
+            return [NSString localizedStringWithFormat:@"Updated %@", [self.dateFormatter stringFromDate:date]];
+        case TRWeatherUpdateStatusFailed:
+            return NSLocalizedString(@"Update Failed", nil);
+    }
 }
 
 @end

--- a/Tropos/Formatters/TRDateFormatter.h
+++ b/Tropos/Formatters/TRDateFormatter.h
@@ -1,0 +1,5 @@
+@interface TRDateFormatter : NSObject
+
+- (NSString *)stringFromDate:(NSDate *)date;
+
+@end

--- a/Tropos/Formatters/TRDateFormatter.m
+++ b/Tropos/Formatters/TRDateFormatter.m
@@ -1,0 +1,46 @@
+#import "TRDateFormatter.h"
+
+@interface TRDateFormatter ()
+
+@property (nonatomic) NSCalendar *calendar;
+@property (nonatomic) NSDateFormatter *dateFormatter;
+
+@end
+
+@implementation TRDateFormatter
+
+- (instancetype)init
+{
+    self = [super init];
+    if (!self) return nil;
+
+    self.calendar = [NSCalendar currentCalendar];
+    self.dateFormatter = [NSDateFormatter new];
+
+    return self;
+}
+
+- (NSString *)stringFromDate:(NSDate *)date
+{
+    NSDateComponents *components = [self.calendar components:(NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond) fromDate:date toDate:[NSDate date] options:kNilOptions];
+
+    if (components.day > 0) {
+        self.dateFormatter.dateStyle = NSDateFormatterShortStyle;
+        self.dateFormatter.timeStyle = NSDateFormatterNoStyle;
+        return [self.dateFormatter stringFromDate:date];
+    } else if (components.hour > 0) {
+        self.dateFormatter.dateStyle = NSDateFormatterNoStyle;
+        self.dateFormatter.timeStyle = NSDateFormatterShortStyle;
+        return [self.dateFormatter stringFromDate:date];
+    } else if (components.minute > 0) {
+        NSString *unit = (components.minute == 1)? @"minute" : @"minutes";
+        return [NSString stringWithFormat:@"%zd %@ ago", components.minute, unit];
+    } else if (components.second > 5) {
+        NSString *unit = (components.second == 1)? @"second" : @"seconds";
+        return [NSString stringWithFormat:@"%zd %@ ago", components.second, unit];
+    } else {
+        return NSLocalizedString(@"just now", nil);
+    }
+}
+
+@end

--- a/Tropos/ViewControllers/TRWeatherViewController.m
+++ b/Tropos/ViewControllers/TRWeatherViewController.m
@@ -35,8 +35,9 @@
 {
     [super viewDidLoad];
     self.controller = [TRWeatherController new];
+    RAC(self.cityLabel, text) = [self.controller locationName];
+    RAC(self.lastUpdatedLabel, text) = [self.controller status];
     [self.KVOController observe:self.controller keyPath:@"weatherViewModel" options:(NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew) action:@selector(viewModelDidChange:object:)];
-    [self.KVOController observe:self.controller keyPath:@"statusViewModel" options:(NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew) action:@selector(statusViewModelDidChange:object:)];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(refresh) name:UIApplicationWillEnterForegroundNotification object:nil];
 }
 
@@ -67,12 +68,6 @@
     self.windSpeedLabel.text = controller.weatherViewModel.formattedWindSpeed;
     self.precipitationMeterView.precipitationProbability = controller.weatherViewModel.precipitationProbability;
     self.conditionsDescriptionLabel.attributedText = controller.weatherViewModel.attributedTemperatureComparison;
-}
-
-- (void)statusViewModelDidChange:(NSDictionary *)changes object:(TRWeatherController *)controller
-{
-    self.cityLabel.text = controller.statusViewModel.location;
-    self.lastUpdatedLabel.text = controller.statusViewModel.status;
 }
 
 @end


### PR DESCRIPTION
We've removed the `TRWeatherStatusViewModel` in favor of exposing signals for the location and status labels. Now we maintain some internal state `lastUpdatedDate` and `updateStatus` that is updated throughout the weather update process.

We publicly expose two new `RACSignal`s, `locationName` and `status`. `locationName` sends an event whenever the internal `weatherLocation` object changes. We compute a new `status` by combining the latest events from 3 signals; an interval signal that fires every second, a signal derived from observing `lastUpdatedDate` and a signal derived from observing `updateStatus`. When either of these signals sends a new event, we combine all of the latest values and reduce them into a string by converting `updateStatus` into a string and running `lastUpdatedDate` through the new `TRDateFormatter`. The result is returned from the signal but is limited by the final RAC operation in the chain, `distinctUntilChanged`. This ensures that the signal only sends the reduced string to the subscriber if it's different from the last sent event.
