### PR TITLE
Take inverse of contentOffset instead of abs value

### DIFF
--- a/Tropos/Categories/UIScrollView+TRReactiveCocoa.m
+++ b/Tropos/Categories/UIScrollView+TRReactiveCocoa.m
@@ -15,7 +15,7 @@
 {
     return [[RACObserve(self, contentOffset) map:^id(NSValue *contentOffset) {
         CGFloat yOffset = (CGFloat)floor(contentOffset.CGPointValue.y);
-        return @(fabs(yOffset));
+        return @(-1 * yOffset);
     }]
     distinctUntilChanged]
     ;


### PR DESCRIPTION
Fixes #73.

By taking the absolute, we found ourselves in a situation where
two possible raw `contentOffset` values from the scroll view could
satisy the conditions we used to determine whether a refresh has
triggered.

When dragging the scroll view down, the `contentOffset` begins to
move from 0 into positive values. When scrolling up, the `contentOffset`
trends negative. When calculating the `verticalScrollAmountChanged`,
we were taking all values and making them positive using `fabs()`.
This meant that even when scrolling down to the forecast area (moving the content view up
and making the `contentOffset` trend negative, we would inadvertently
trigger another refresh. The result of triggering the refresh changes
the `contentInset` and `contentOffset` of the scroll view out from under us
causing the view to snap back up to its resting state of `{0, 0}`.

Instead of `fabs()` we'll now just invert the negative `contentOffset`
into a positive value to make calculations a little more sane since
we only care about the content offsets `<= 0` when implementing pull to refresh.
