### PR TITLE
Disable Mixpanel's AB test designer gesture

### DIFF
--- a/Tropos/Controllers/TRAnalyticsController.m
+++ b/Tropos/Controllers/TRAnalyticsController.m
@@ -2,6 +2,8 @@
 #import "TRAnalyticsController.h"
 #import "Secrets.h"
 
+#define DISABLE_MIXPANEL_AB_DESIGNER
+
 @implementation TRAnalyticsController
 
 #pragma mark - Initialization


### PR DESCRIPTION
Mixpanel installs a 4-finger long press gesture on the application's key window
in order to enable a connection between the device and the live A/B test
designer on their dashboard. I don't want this feature and I definitely don't
want their gestures in our app.
