### PR TITLE
Add analytics event for viewing the forecast

### DIFF
--- a/Resources/Storyboards/Main.storyboard
+++ b/Resources/Storyboards/Main.storyboard
@@ -69,7 +69,7 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Yw-zl-yWp" userLabel="Current Conditions View">
                                         <rect key="frame" x="0.0" y="0.0" width="600" height="536"/>
                                         <subviews>
-                                            <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r7S-cF-Z7O" userLabel="Forecast Container View">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r7S-cF-Z7O" userLabel="Forecast Container View">
                                                 <rect key="frame" x="48" y="167" width="532" height="203"/>
                                                 <subviews>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ef5-IL-xEe" userLabel="Conditions Icon" customClass="TRImageView">
@@ -78,7 +78,7 @@
                                                             <constraint firstAttribute="width" secondItem="Ef5-IL-xEe" secondAttribute="height" multiplier="1:1" id="FD7-Zx-h5o"/>
                                                         </constraints>
                                                     </imageView>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="It's warmer today than yesterday at this time." lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4aa-2F-UFk" userLabel="Conditions Description" customClass="TRLabel">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="It's warmer today than yesterday at this time." lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4aa-2F-UFk" userLabel="Conditions Description" customClass="TRLabel">
                                                         <rect key="frame" x="0.0" y="139" width="522" height="64"/>
                                                         <fontDescription key="fontDescription" name="DINNextLTPro-Light" family="DIN Next LT Pro" pointSize="32"/>
                                                         <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
@@ -161,9 +161,9 @@
                                             </mask>
                                         </variation>
                                     </view>
-                                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BVN-q4-01Z" userLabel="Refresh Control" customClass="TRRefreshControl">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BVN-q4-01Z" userLabel="Refresh Control" customClass="TRRefreshControl">
                                         <subviews>
-                                            <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xyb-8W-ran" customClass="TRRefreshView">
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xyb-8W-ran" customClass="TRRefreshView">
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             </view>
                                         </subviews>
@@ -212,6 +212,9 @@
                                         <exclude reference="kJl-sP-q1V"/>
                                     </mask>
                                 </variation>
+                                <connections>
+                                    <outlet property="delegate" destination="zCV-BE-JFf" id="Bbq-k6-bPM"/>
+                                </connections>
                             </scrollView>
                             <navigationBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8pq-jS-l9S" customClass="TRNavigationBar">
                                 <rect key="frame" x="0.0" y="20" width="600" height="44"/>
@@ -224,16 +227,16 @@
                                     <navigationItem id="PBf-Jt-sGO">
                                         <nil key="title"/>
                                         <view key="titleView" contentMode="scaleToFill" id="I2V-ym-11z">
-                                            <rect key="frame" x="180" y="5.5" width="240" height="33"/>
+                                            <rect key="frame" x="180" y="6" width="240" height="33"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Updated 19 seconds ago" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9cT-VN-8BL" customClass="TRLabel">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Updated 19 seconds ago" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9cT-VN-8BL" customClass="TRLabel">
                                                     <rect key="frame" x="0.0" y="20" width="240" height="13"/>
                                                     <fontDescription key="fontDescription" name="DINNextLTPro-Light" family="DIN Next LT Pro" pointSize="13"/>
                                                     <color key="textColor" red="0.63137254901960782" green="0.65490196078431373" blue="0.69411764705882351" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" misplaced="YES" text="SAN FRANCISCO, CA" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lu5-Qh-6jG" customClass="TRLabel">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="SAN FRANCISCO, CA" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lu5-Qh-6jG" customClass="TRLabel">
                                                     <rect key="frame" x="0.0" y="0.0" width="240" height="20"/>
                                                     <fontDescription key="fontDescription" name="DINNextLTPro-Light" family="DIN Next LT Pro" pointSize="17"/>
                                                     <color key="textColor" red="0.63137254901960782" green="0.65490196078431373" blue="0.69411764705882351" alpha="1" colorSpace="calibratedRGB"/>

--- a/Tropos/Categories/UIScrollView+TRReactiveCocoa.h
+++ b/Tropos/Categories/UIScrollView+TRReactiveCocoa.h
@@ -3,4 +3,6 @@
 @property (nonatomic, readonly) RACSignal *verticalAmountScrolledSignal;
 @property (nonatomic, readonly) RACSignal *deceleratingSignal;
 
+@property (nonatomic, readonly) BOOL isScrolledToBottom;
+
 @end

--- a/Tropos/Categories/UIScrollView+TRReactiveCocoa.m
+++ b/Tropos/Categories/UIScrollView+TRReactiveCocoa.m
@@ -21,4 +21,9 @@
     ;
 }
 
+- (BOOL)isScrolledToBottom
+{
+    return (self.contentOffset.y == self.contentSize.height - CGRectGetHeight(self.bounds));
+}
+
 @end

--- a/Tropos/Controllers/TRAnalyticsController.h
+++ b/Tropos/Controllers/TRAnalyticsController.h
@@ -4,6 +4,7 @@
 
 + (instancetype)sharedController;
 - (void)install;
+- (void)trackEventNamed:(NSString *)eventName;
 - (void)trackEvent:(id<TRAnalyticsEvent>)event;
 - (void)trackError:(NSError *)error eventName:(NSString *)eventName;
 

--- a/Tropos/Controllers/TRAnalyticsController.m
+++ b/Tropos/Controllers/TRAnalyticsController.m
@@ -30,6 +30,11 @@
 #endif
 }
 
+- (void)trackEventNamed:(NSString *)eventName
+{
+    [[Mixpanel sharedInstance] track:eventName];
+}
+
 - (void)trackEvent:(id<TRAnalyticsEvent>)event
 {
     [[Mixpanel sharedInstance] track:event.eventName properties:event.eventProperties];


### PR DESCRIPTION
- Add `UIScrollView` category method to determine if the scroll view is
  resting at the bottom
- Add method `TRAnalyticsController` for tracking events without
  properties
- Watch for the scroll view to either stop as a result of decelerating
  or when dragging ends without a final velocity. Merge the two signals
  together, filter when the scroll view is not resting at the bottom and
  map replace the value to `@“Viewed Forecast”. Then lift the
  `-trackEventNamed:`method on`TRAnalyticsController` with the merged
  signal.
