### PR TITLE
Always reload from network ignoring cache

### DIFF
--- a/Tropos/Controllers/TRForecastController.m
+++ b/Tropos/Controllers/TRForecastController.m
@@ -23,6 +23,7 @@ static NSString *const TRForecastAPIExclusions = @"minutely,hourly,alerts,flags"
 
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     configuration.HTTPAdditionalHeaders = @{@"Accept": @"application/json"};
+    configuration.requestCachePolicy = NSURLRequestReloadIgnoringCacheData;
     self.session = [NSURLSession sessionWithConfiguration:configuration];
 
     return self;


### PR DESCRIPTION
Fixes an issue where the location string could be incorrect despite a
successful location update. Occasionally, cached weather updates were
being returned from the networking controller. Currently, the location
string is derivative of the weather update meaning that, while the
forecast and location were in sync, the entire display isn’t relevant
in any way since it can be an old weather update.
