### PR TITLE
Cache forecast to disk

### DIFF
--- a/Tropos.xcodeproj/project.pbxproj
+++ b/Tropos.xcodeproj/project.pbxproj
@@ -63,6 +63,9 @@
 		CE5D7F3B45F980082E1BCA30 /* LaunchScreen.xib in Sources */ = {isa = PBXBuildFile; fileRef = B6D58F8AA6976EA1B35682B7 /* LaunchScreen.xib */; };
 		CFC0721C2D9EFFD3C3AE11A7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 059D0BDDF8DCE56549A4C9C6 /* Images.xcassets */; };
 		D7DD1B8AD495AFA4EC1CEFF9 /* TRAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A6B1ADBC73A8A2EF7FB4E257 /* TRAppDelegate.m */; };
+		E7A895541AFD11AA0023205B /* TRApplicationController.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A895531AFD11AA0023205B /* TRApplicationController.m */; };
+		E7A8955D1AFD1CAA0023205B /* TRWeatherUpdateCache.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A8955C1AFD1CAA0023205B /* TRWeatherUpdateCache.m */; };
+		E7E4A3A21B069BB500F489E3 /* TRWeatherUpdateCacheSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = E7E4A3A11B069BB500F489E3 /* TRWeatherUpdateCacheSpec.m */; };
 		E7E8D6031ACF0B9700BD8364 /* TRWeatherUpdateSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = E7E8D6021ACF0B9700BD8364 /* TRWeatherUpdateSpec.m */; };
 /* End PBXBuildFile section */
 
@@ -186,6 +189,11 @@
 		E2B218FB5F097AAE3080F4DD /* UnitTests-Prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UnitTests-Prefix.pch"; sourceTree = "<group>"; };
 		E59B090E67C8BD269D3CD9DB /* Main.storyboard */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		E799194B1ACEE75C00A5600C /* Secrets.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Secrets.h; sourceTree = "<group>"; };
+		E7A895521AFD11AA0023205B /* TRApplicationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TRApplicationController.h; sourceTree = "<group>"; };
+		E7A895531AFD11AA0023205B /* TRApplicationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRApplicationController.m; sourceTree = "<group>"; };
+		E7A8955B1AFD1CAA0023205B /* TRWeatherUpdateCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TRWeatherUpdateCache.h; sourceTree = "<group>"; };
+		E7A8955C1AFD1CAA0023205B /* TRWeatherUpdateCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRWeatherUpdateCache.m; sourceTree = "<group>"; };
+		E7E4A3A11B069BB500F489E3 /* TRWeatherUpdateCacheSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRWeatherUpdateCacheSpec.m; sourceTree = "<group>"; };
 		E7E8D6021ACF0B9700BD8364 /* TRWeatherUpdateSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRWeatherUpdateSpec.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -227,6 +235,8 @@
 				4D9CA3611A5CB544009E24DD /* TRSettingsController.m */,
 				4D72D1281A7330E700FAB67B /* TRGeocodeController.h */,
 				4D72D1291A7330E700FAB67B /* TRGeocodeController.m */,
+				E7A895521AFD11AA0023205B /* TRApplicationController.h */,
+				E7A895531AFD11AA0023205B /* TRApplicationController.m */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -310,6 +320,8 @@
 				4DEDF4F51A6FA682006F3F11 /* TRWeatherUpdate.m */,
 				4D98E9891A80C89600856412 /* TRDailyForecast.h */,
 				4D98E98A1A80C89600856412 /* TRDailyForecast.m */,
+				E7A8955B1AFD1CAA0023205B /* TRWeatherUpdateCache.h */,
+				E7A8955C1AFD1CAA0023205B /* TRWeatherUpdateCache.m */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -455,6 +467,7 @@
 				4D9CA35C1A5C7672009E24DD /* TRBearingFormatterSpec.m */,
 				4DA79AC01A68806600C3539D /* UIColor_TRTemperatureColorsSpec.m */,
 				E7E8D6021ACF0B9700BD8364 /* TRWeatherUpdateSpec.m */,
+				E7E4A3A11B069BB500F489E3 /* TRWeatherUpdateCacheSpec.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -751,6 +764,7 @@
 				4D7CDEBF1A46DD030038DD33 /* NSError+TRErrors.m in Sources */,
 				4D98E98B1A80C89600856412 /* TRDailyForecast.m in Sources */,
 				C2E44CF81A3B7538009CC844 /* TRTemperature.m in Sources */,
+				E7A895541AFD11AA0023205B /* TRApplicationController.m in Sources */,
 				4D98E9851A80C43F00856412 /* TRDailyForecastView.m in Sources */,
 				4D9A00061A9D61CD000835A9 /* TRAnalyticsController.m in Sources */,
 				4D7CDECC1A47E13F0038DD33 /* TRTemperatureComparisonFormatter.m in Sources */,
@@ -761,6 +775,7 @@
 				CE5D7F3B45F980082E1BCA30 /* LaunchScreen.xib in Sources */,
 				C9318C8461EB5FE3914F9AC0 /* main.m in Sources */,
 				4D72D12A1A7330E700FAB67B /* TRGeocodeController.m in Sources */,
+				E7A8955D1AFD1CAA0023205B /* TRWeatherUpdateCache.m in Sources */,
 				4D3386FF1A5D27260087B88F /* TRTemperatureFormatter.m in Sources */,
 				4D7CDEBC1A46D3610038DD33 /* CLLocation+TRRecentLocation.m in Sources */,
 				4D4955521A8C2B5D0066F278 /* UIImage+TRColorBackdrop.m in Sources */,
@@ -777,6 +792,7 @@
 			files = (
 				E7E8D6031ACF0B9700BD8364 /* TRWeatherUpdateSpec.m in Sources */,
 				4D9CA35D1A5C7672009E24DD /* TRBearingFormatterSpec.m in Sources */,
+				E7E4A3A21B069BB500F489E3 /* TRWeatherUpdateCacheSpec.m in Sources */,
 				C2E44CFE1A3B7C14009CC844 /* TRTemperatureSpec.m in Sources */,
 				4DA79AC11A68806600C3539D /* UIColor_TRTemperatureColorsSpec.m in Sources */,
 			);
@@ -980,6 +996,11 @@
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 				);
 				GCC_PREFIX_HEADER = "UnitTests/Resources/UnitTests-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"COCOAPODS=1",
+					"XCODE_VERSION=$(XCODE_VERSION_MAJOR)",
+				);
 				INFOPLIST_FILE = "UnitTests/Resources/UnitTests-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/Tropos/Controllers/TRAppDelegate.h
+++ b/Tropos/Controllers/TRAppDelegate.h
@@ -1,5 +1,8 @@
+#import "TRApplicationController.h"
+
 @interface TRAppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
+@property (strong, nonatomic) TRApplicationController *applicationController;
 
 @end

--- a/Tropos/Controllers/TRAppDelegate.m
+++ b/Tropos/Controllers/TRAppDelegate.m
@@ -2,6 +2,7 @@
 #import "TRAppDelegate.h"
 #import "TRAnalyticsController.h"
 #import "TRSettingsController.h"
+#import "TRApplicationController.h"
 
 #ifndef DEBUG
 #import "Secrets.h"
@@ -20,6 +21,10 @@
 #endif
 
     [[TRSettingsController new] registerSettings];
+
+    self.applicationController = [TRApplicationController new];
+    self.window.rootViewController = self.applicationController.rootViewController;
+    [self.window makeKeyAndVisible];
 
     return YES;
 }

--- a/Tropos/Controllers/TRApplicationController.h
+++ b/Tropos/Controllers/TRApplicationController.h
@@ -1,0 +1,7 @@
+#import "TRWeatherViewController.h"
+
+@interface TRApplicationController : NSObject
+
+@property (nonatomic) TRWeatherViewController *rootViewController;
+
+@end

--- a/Tropos/Controllers/TRApplicationController.m
+++ b/Tropos/Controllers/TRApplicationController.m
@@ -1,0 +1,17 @@
+#import "TRApplicationController.h"
+#import "TRWeatherViewController.h"
+
+@implementation TRApplicationController
+
+- (instancetype)init
+{
+    self = [super init];
+    if (!self) { return nil; }
+
+    UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:[NSBundle mainBundle]];
+    self.rootViewController = [storyboard instantiateInitialViewController];
+
+    return self;
+}
+
+@end

--- a/Tropos/Models/TRWeatherUpdate.h
+++ b/Tropos/Models/TRWeatherUpdate.h
@@ -1,7 +1,7 @@
 @class CLPlacemark;
 @class TRTemperature;
 
-@interface TRWeatherUpdate : NSObject
+@interface TRWeatherUpdate : NSObject <NSCoding>
 
 @property (nonatomic, copy, readonly) NSString *city;
 @property (nonatomic, copy, readonly) NSString *state;

--- a/Tropos/Models/TRWeatherUpdate.m
+++ b/Tropos/Models/TRWeatherUpdate.m
@@ -18,16 +18,20 @@
 @property (nonatomic, copy, readwrite) NSArray *dailyForecasts;
 
 @property (nonatomic) CLPlacemark *placemark;
+@property (nonatomic) NSDictionary *currentConditions;
+@property (nonatomic) NSDictionary *yesterdaysConditions;
 
 @end
 
 @implementation TRWeatherUpdate
 
-- (instancetype)initWithPlacemark:(CLPlacemark *)placemark currentConditionsJSON:(id)currentConditionsJSON yesterdaysConditionsJSON:(id)yesterdaysConditionsJSON
+- (instancetype)initWithPlacemark:(CLPlacemark *)placemark currentConditionsJSON:(NSDictionary *)currentConditionsJSON yesterdaysConditionsJSON:(NSDictionary *)yesterdaysConditionsJSON
 {
     self = [super init];
     if (!self) return nil;
 
+    self.currentConditions = currentConditionsJSON;
+    self.yesterdaysConditions = yesterdaysConditionsJSON;
     self.placemark = placemark;
     self.city = placemark.locality;
     self.state = placemark.administrativeArea;
@@ -66,6 +70,28 @@
     } else if (self.currentTemperature.fahrenheitValue > self.currentHigh.fahrenheitValue) {
         self.currentHigh = self.currentTemperature;
     }
+}
+
+#pragma mark - NSCoding
+
+static NSString *const TRCurrentConditionsKey = @"TRCurrentConditions";
+static NSString *const TRYesterdaysConditionsKey = @"TRYesterdaysConditionsConditions";
+static NSString *const TRPlacemarkKey = @"TRPlacemark";
+
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+    [coder encodeObject:self.currentConditions forKey:TRCurrentConditionsKey];
+    [coder encodeObject:self.yesterdaysConditions forKey:TRYesterdaysConditionsKey];
+    [coder encodeObject:self.placemark forKey:TRPlacemarkKey];
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+    CLPlacemark *placemark = [coder decodeObjectForKey:TRPlacemarkKey];
+    NSDictionary *currentConditions = [coder decodeObjectForKey:TRCurrentConditionsKey];
+    NSDictionary *yesterdaysConditions = [coder decodeObjectForKey:TRYesterdaysConditionsKey];
+
+    return [self initWithPlacemark:placemark currentConditionsJSON:currentConditions yesterdaysConditionsJSON:yesterdaysConditions];
 }
 
 @end

--- a/Tropos/Models/TRWeatherUpdateCache.h
+++ b/Tropos/Models/TRWeatherUpdateCache.h
@@ -1,0 +1,8 @@
+#import "TRWeatherUpdate.h"
+
+@interface TRWeatherUpdateCache : NSObject
+
+- (TRWeatherUpdate *)latestWeatherUpdate;
+- (BOOL)archiveWeatherUpdate:(TRWeatherUpdate *)update;
+
+@end

--- a/Tropos/Models/TRWeatherUpdateCache.m
+++ b/Tropos/Models/TRWeatherUpdateCache.m
@@ -1,0 +1,41 @@
+#import "TRWeatherUpdateCache.h"
+
+static NSString *const TRLatestWeatherUpdateFileName = @"TRLatestWeatherUpdateFile";
+
+@interface TRWeatherUpdateCache ()
+
+@property (nonatomic) NSURL *latestWeatherUpdateURL;
+
+@end
+
+@implementation TRWeatherUpdateCache
+
+- (instancetype)init
+{
+    self = [super init];
+    if (!self) { return nil; }
+
+    NSURL *documentsPath = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory
+                                                                  inDomains:NSUserDomainMask] firstObject];
+
+    self.latestWeatherUpdateURL = [documentsPath URLByAppendingPathComponent:TRLatestWeatherUpdateFileName];
+
+    return self;
+}
+
+- (TRWeatherUpdate *)latestWeatherUpdate
+{
+    return [NSKeyedUnarchiver unarchiveObjectWithFile:[self latestWeatherUpdateFilePath]];
+}
+
+- (BOOL)archiveWeatherUpdate:(TRWeatherUpdate *)update
+{
+    return [NSKeyedArchiver archiveRootObject:update toFile:[self latestWeatherUpdateFilePath]];
+}
+
+- (NSString *)latestWeatherUpdateFilePath
+{
+    return [self.latestWeatherUpdateURL path];
+}
+
+@end

--- a/UnitTests/Tests/TRWeatherUpdateCacheSpec.m
+++ b/UnitTests/Tests/TRWeatherUpdateCacheSpec.m
@@ -1,0 +1,83 @@
+@import CoreLocation;
+#import "TRWeatherUpdate.h"
+#import "TRWeatherUpdateCache.h"
+#import <OCMock/OCMock.h>
+
+@interface TRWeatherUpdateCache (Tests)
+
+- (NSString *)latestWeatherUpdateFilePath;
+- (NSURL *)latestWeatherUpdateURL;
+
+@end
+
+SpecBegin(TRWeatherUpdateCache)
+
+CLPlacemark* (^stubbedPlacemark) () = ^CLPlacemark* {
+    CLPlacemark *placemark = OCMClassMock([CLPlacemark class]);
+    OCMStub([placemark locality]).andReturn(@"");
+    OCMStub([placemark administrativeArea]).andReturn(@"");
+    return placemark;
+};
+
+NSURL* (^weatherUpdateURLForTesting) () = ^NSURL* {
+    NSURL *documentsPath = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory
+                                                                  inDomains:NSUserDomainMask] firstObject];
+    return [documentsPath URLByAppendingPathComponent:@"TestWeatherUpdate"];
+};
+
+void (^resetFilesystem) () = ^{
+    [[NSFileManager defaultManager] removeItemAtURL:weatherUpdateURLForTesting() error:nil];
+};
+
+describe(@"TRWeatherUpdateCache", ^{
+    beforeEach(^{
+        resetFilesystem();
+    });
+
+    context(@"-init", ^{
+        it(@"sets the latestWeatherUpdateURL", ^{
+            TRWeatherUpdateCache *cache = [[TRWeatherUpdateCache alloc] init];
+
+            expect(cache.latestWeatherUpdateURL).toNot.beNil();
+        });
+    });
+
+    context(@"-archiveLatestWeatherUpdate", ^{
+        it(@"archives the object to disk", ^{
+            NSURL *weatherUpdateURL = weatherUpdateURLForTesting();
+            TRWeatherUpdateCache *cache = OCMPartialMock([[TRWeatherUpdateCache alloc] init]);
+            OCMStub([cache latestWeatherUpdateFilePath]).andReturn([weatherUpdateURL path]);
+            TRWeatherUpdate *update = [[TRWeatherUpdate alloc] initWithPlacemark:stubbedPlacemark() currentConditionsJSON:@{} yesterdaysConditionsJSON:@{}];
+
+            [cache archiveWeatherUpdate:update];
+            
+            expect([[NSFileManager defaultManager] isReadableFileAtPath:[weatherUpdateURL path]]).to.equal(YES);
+        });
+    });
+
+    context(@"-latestWeatherUpdate", ^{
+        it(@"returns nil when not archived", ^{
+            NSURL *weatherUpdateURL = weatherUpdateURLForTesting();
+            TRWeatherUpdateCache *cache = OCMPartialMock([[TRWeatherUpdateCache alloc] init]);
+            OCMStub([cache latestWeatherUpdateFilePath]).andReturn([weatherUpdateURL path]);
+
+            TRWeatherUpdate* unarchivedWeatherUpdate = [cache latestWeatherUpdate];
+
+            expect(unarchivedWeatherUpdate).to.beNil();
+        });
+
+        it(@"returns an initialized TRWeatherUpdate when archive exists", ^{
+            NSURL *weatherUpdateURL = weatherUpdateURLForTesting();
+            TRWeatherUpdateCache *cache = OCMPartialMock([[TRWeatherUpdateCache alloc] init]);
+            OCMStub([cache latestWeatherUpdateFilePath]).andReturn([weatherUpdateURL path]);
+            TRWeatherUpdate *update = [[TRWeatherUpdate alloc] initWithPlacemark:stubbedPlacemark() currentConditionsJSON:@{} yesterdaysConditionsJSON:@{}];
+            [cache archiveWeatherUpdate:update];
+
+            TRWeatherUpdate* unarchivedWeatherUpdate = [cache latestWeatherUpdate];
+
+            expect(unarchivedWeatherUpdate).to.beInstanceOf([TRWeatherUpdate class]);
+        });
+    });
+});
+
+SpecEnd


### PR DESCRIPTION
This PR implements caches the weather update to disk whenever it's requested. This cache is then used when the app is loaded so the user doesn't have to wait for the update to complete to have something on screen.

I'm opening this as a separate PR than background fetch. This sets up the
prerequisite things we need so I can come back with another PR that uses this
to refresh this data in the background.

In this gif:
1st app start is fresh with no cache.
2nd is with the cache

![troposcache](https://cloud.githubusercontent.com/assets/3799709/7547089/4998a7cc-f59b-11e4-9bea-3ac393878e0a.gif)
