### PR TITLE
Background Fetch

### DIFF
--- a/Resources/Other-Sources/Info.plist
+++ b/Resources/Other-Sources/Info.plist
@@ -26,6 +26,10 @@
 	<array>
 		<string>DINNextLTPro-UltraLight.otf</string>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Resources/Other-Sources/en.lproj/InfoPlist.strings
+++ b/Resources/Other-Sources/en.lproj/InfoPlist.strings
@@ -1,2 +1,3 @@
 "CFBundleDisplayName" = "Tropos";
 "NSLocationWhenInUseUsageDescription" = "Tropos will only use your location to discover current weather conditions and forecasts for your area.";
+"NSLocationAlwaysUsageDescription" = "Tropos will only use your location to stay updated on current weather conditions and forecasts for your area.";

--- a/Tropos.xcodeproj/project.pbxproj
+++ b/Tropos.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		D7DD1B8AD495AFA4EC1CEFF9 /* TRAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A6B1ADBC73A8A2EF7FB4E257 /* TRAppDelegate.m */; };
 		E7A895541AFD11AA0023205B /* TRApplicationController.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A895531AFD11AA0023205B /* TRApplicationController.m */; };
 		E7A8955D1AFD1CAA0023205B /* TRWeatherUpdateCache.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A8955C1AFD1CAA0023205B /* TRWeatherUpdateCache.m */; };
+		E7B3B9271B34EDFE00BDD5A4 /* TRApplicationControllerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = E7B3B9261B34EDFE00BDD5A4 /* TRApplicationControllerSpec.m */; };
 		E7E4A3A21B069BB500F489E3 /* TRWeatherUpdateCacheSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = E7E4A3A11B069BB500F489E3 /* TRWeatherUpdateCacheSpec.m */; };
 		E7E8D6031ACF0B9700BD8364 /* TRWeatherUpdateSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = E7E8D6021ACF0B9700BD8364 /* TRWeatherUpdateSpec.m */; };
 /* End PBXBuildFile section */
@@ -202,6 +203,7 @@
 		E7A895531AFD11AA0023205B /* TRApplicationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRApplicationController.m; sourceTree = "<group>"; };
 		E7A8955B1AFD1CAA0023205B /* TRWeatherUpdateCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TRWeatherUpdateCache.h; sourceTree = "<group>"; };
 		E7A8955C1AFD1CAA0023205B /* TRWeatherUpdateCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRWeatherUpdateCache.m; sourceTree = "<group>"; };
+		E7B3B9261B34EDFE00BDD5A4 /* TRApplicationControllerSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TRApplicationControllerSpec.m; path = Controllers/TRApplicationControllerSpec.m; sourceTree = "<group>"; };
 		E7E4A3A11B069BB500F489E3 /* TRWeatherUpdateCacheSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRWeatherUpdateCacheSpec.m; sourceTree = "<group>"; };
 		E7E8D6021ACF0B9700BD8364 /* TRWeatherUpdateSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRWeatherUpdateSpec.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -480,6 +482,7 @@
 				E7E8D6021ACF0B9700BD8364 /* TRWeatherUpdateSpec.m */,
 				E7E4A3A11B069BB500F489E3 /* TRWeatherUpdateCacheSpec.m */,
 				C44ECB211AFD00E300B1195E /* TRPrecipitationSpec.m */,
+				E7B3B9281B34EE0500BDD5A4 /* Controllers */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -499,6 +502,14 @@
 				22FE01C01AF3F5550085B494 /* Secrets.h */,
 			);
 			path = Tropos;
+			sourceTree = "<group>";
+		};
+		E7B3B9281B34EE0500BDD5A4 /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				E7B3B9261B34EDFE00BDD5A4 /* TRApplicationControllerSpec.m */,
+			);
+			name = Controllers;
 			sourceTree = "<group>";
 		};
 		F7756A61DA7A0F0958F6D728 /* Categories */ = {
@@ -595,6 +606,11 @@
 				TargetAttributes = {
 					45ADD324EABFD89F9E640007 = {
 						DevelopmentTeam = 8E7TQ638ZD;
+						SystemCapabilities = {
+							com.apple.BackgroundModes = {
+								enabled = 1;
+							};
+						};
 					};
 				};
 			};
@@ -807,6 +823,7 @@
 			files = (
 				C44ECB221AFD00E300B1195E /* TRPrecipitationSpec.m in Sources */,
 				E7E8D6031ACF0B9700BD8364 /* TRWeatherUpdateSpec.m in Sources */,
+				E7B3B9271B34EDFE00BDD5A4 /* TRApplicationControllerSpec.m in Sources */,
 				4D9CA35D1A5C7672009E24DD /* TRBearingFormatterSpec.m in Sources */,
 				E7E4A3A21B069BB500F489E3 /* TRWeatherUpdateCacheSpec.m in Sources */,
 				C2E44CFE1A3B7C14009CC844 /* TRTemperatureSpec.m in Sources */,

--- a/Tropos.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Tropos.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Tropos/Controllers/TRAppDelegate.m
+++ b/Tropos/Controllers/TRAppDelegate.m
@@ -24,10 +24,24 @@
     [[TRSettingsController new] registerSettings];
 
     self.applicationController = [TRApplicationController new];
+
+    [self.applicationController setMinimumBackgroundFetchIntervalForApplication:application];
+
     self.window.rootViewController = self.applicationController.rootViewController;
     [self.window makeKeyAndVisible];
 
     return YES;
+}
+
+- (void)application:(UIApplication *)application performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
+{
+    RACSignal *signal = [self.applicationController performBackgroundFetch];
+
+    [signal subscribeNext:^(id x) {
+        completionHandler(UIBackgroundFetchResultNewData);
+    } error:^(NSError *error) {
+        completionHandler(UIBackgroundFetchResultFailed);
+    }];
 }
 
 @end

--- a/Tropos/Controllers/TRApplicationController.h
+++ b/Tropos/Controllers/TRApplicationController.h
@@ -4,4 +4,7 @@
 
 @property (nonatomic) TRWeatherViewController *rootViewController;
 
+- (RACSignal *)performBackgroundFetch;
+- (void)setMinimumBackgroundFetchIntervalForApplication:(UIApplication *)application;
+
 @end

--- a/Tropos/Controllers/TRApplicationController.m
+++ b/Tropos/Controllers/TRApplicationController.m
@@ -1,5 +1,14 @@
+@import CoreLocation;
 #import "TRApplicationController.h"
-#import "TRWeatherViewController.h"
+#import "TRWeatherController.h"
+#import "TRLocationController.h"
+
+@interface TRApplicationController ()
+
+@property (nonatomic) TRWeatherController *weatherController;
+@property (nonatomic) TRLocationController *locationController;
+
+@end
 
 @implementation TRApplicationController
 
@@ -11,7 +20,24 @@
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Main" bundle:[NSBundle mainBundle]];
     self.rootViewController = [storyboard instantiateInitialViewController];
 
+    self.weatherController = [TRWeatherController new];
+    self.locationController = [TRLocationController new];
+
     return self;
+}
+
+- (RACSignal *)performBackgroundFetch
+{
+    return [self.weatherController.updateWeatherCommand execute:self];
+}
+
+- (void)setMinimumBackgroundFetchIntervalForApplication:(UIApplication *)application
+{
+    if ([self.locationController authorizationStatusEqualTo:kCLAuthorizationStatusAuthorizedAlways]) {
+        [application setMinimumBackgroundFetchInterval:UIApplicationBackgroundFetchIntervalMinimum];
+    } else {
+        [application setMinimumBackgroundFetchInterval:UIApplicationBackgroundFetchIntervalNever];
+    }
 }
 
 @end

--- a/Tropos/Controllers/TRLocationController.h
+++ b/Tropos/Controllers/TRLocationController.h
@@ -1,6 +1,7 @@
 @interface TRLocationController : NSObject
 
-- (RACSignal *)requestWhenInUseAuthorization;
+- (RACSignal *)requestAlwaysAuthorization;
 - (RACSignal *)updateCurrentLocation;
+- (BOOL)authorizationStatusEqualTo:(CLAuthorizationStatus)status;
 
 @end

--- a/Tropos/Controllers/TRLocationController.m
+++ b/Tropos/Controllers/TRLocationController.m
@@ -28,10 +28,10 @@
 
 #pragma mark - Properties
 
-- (RACSignal *)requestWhenInUseAuthorization
+- (RACSignal *)requestAlwaysAuthorization
 {
     if ([self needsAuthorization]) {
-        [self.locationManager requestWhenInUseAuthorization];
+        [self.locationManager requestAlwaysAuthorization];
         return [self didAuthorize];
     } else {
         return [self authorized];
@@ -57,23 +57,28 @@
     }];
 }
 
+- (BOOL)authorizationStatusEqualTo:(CLAuthorizationStatus)status
+{
+    return [CLLocationManager authorizationStatus] == status;
+}
+
 #pragma mark - Private
 
 - (BOOL)needsAuthorization
 {
-    return ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusNotDetermined);
+    return [self authorizationStatusEqualTo:kCLAuthorizationStatusNotDetermined];
 }
 
 - (RACSignal *)didAuthorize
 {
     return [[[[self didChangeAuthorizationStatus] ignore:@(kCLAuthorizationStatusNotDetermined)] map:^id(NSNumber *status) {
-        return @(status.integerValue == kCLAuthorizationStatusAuthorizedWhenInUse);
+        return @(status.integerValue == kCLAuthorizationStatusAuthorizedWhenInUse || status.integerValue == kCLAuthorizationStatusAuthorizedAlways);
     }] take:1];
 }
 
 - (RACSignal *)authorized
 {
-    BOOL authorized = ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusAuthorizedWhenInUse);
+    BOOL authorized = [self authorizationStatusEqualTo:kCLAuthorizationStatusAuthorizedWhenInUse] || [self authorizationStatusEqualTo:kCLAuthorizationStatusAuthorizedAlways];
     return [RACSignal return:@(authorized)];
 }
 

--- a/Tropos/Controllers/TRWeatherController.m
+++ b/Tropos/Controllers/TRWeatherController.m
@@ -41,7 +41,7 @@
     @weakify(self)
     self.updateWeatherCommand = [[RACCommand alloc] initWithSignalBlock:^RACSignal *(id input) {
         @strongify(self)
-        return [[[[self.locationController requestWhenInUseAuthorization] then:^RACSignal *{
+        return [[[[self.locationController requestAlwaysAuthorization] then:^RACSignal *{
             return [self.locationController updateCurrentLocation];
         }] flattenMap:^RACStream *(CLLocation *location) {
             return [self.geocodeController reverseGeocodeLocation:location];

--- a/UnitTests/Tests/Controllers/TRApplicationControllerSpec.m
+++ b/UnitTests/Tests/Controllers/TRApplicationControllerSpec.m
@@ -1,0 +1,63 @@
+@import CoreLocation;
+#import "TRApplicationController.h"
+#import "TRWeatherController.h"
+#import "TRLocationController.h"
+
+@interface TRApplicationController (Tests)
+
+@property (nonatomic) TRWeatherController *weatherController;
+@property (nonatomic) TRLocationController *locationController;
+
+@end
+
+@interface TRWeatherController (Tests)
+
+@property (nonatomic) RACCommand *updateWeatherCommand;
+
+@end
+
+SpecBegin(TRApplicationController)
+
+TRLocationController* (^locationControllerWithAuthorizationStatusAuthorizedAlwaysEqualTo) (BOOL) = ^TRLocationController* (BOOL enabled){
+    TRLocationController *locationController = OCMPartialMock([[TRLocationController alloc] init]);
+    OCMStub([locationController authorizationStatusEqualTo:kCLAuthorizationStatusAuthorizedAlways]).andReturn(enabled);
+    return locationController;
+};
+
+describe(@"TRApplicationController", ^{
+    describe(@"setMinimimBackgroundFetchIntervalForApplication:", ^{
+        it(@"sets the interval to minimum when authorization is always", ^{
+            UIApplication *application = OCMClassMock([UIApplication class]);
+            TRApplicationController *applicationController = [TRApplicationController new];
+            applicationController.locationController = locationControllerWithAuthorizationStatusAuthorizedAlwaysEqualTo(YES);
+
+            [applicationController setMinimumBackgroundFetchIntervalForApplication:application];
+
+            OCMVerify([application setMinimumBackgroundFetchInterval:UIApplicationBackgroundFetchIntervalMinimum]);
+        });
+
+        it(@"sets the interval to never when authorization is not always", ^{
+            UIApplication *application = OCMClassMock([UIApplication class]);
+            TRApplicationController *applicationController = [TRApplicationController new];
+            applicationController.locationController = locationControllerWithAuthorizationStatusAuthorizedAlwaysEqualTo(NO);
+
+            [applicationController setMinimumBackgroundFetchIntervalForApplication:application];
+
+            OCMVerify([application setMinimumBackgroundFetchInterval:UIApplicationBackgroundFetchIntervalNever]);
+        });
+    });
+
+    describe(@"performBackgroundFetch:", ^{
+        it(@"executes the weatherControllers's updateWeatherCommand", ^{
+            RACCommand *updateWeatherCommand = OCMClassMock([RACCommand class]);
+            TRApplicationController *applicationController = [TRApplicationController new];
+            applicationController.weatherController.updateWeatherCommand = updateWeatherCommand;
+
+            [applicationController performBackgroundFetch];
+
+            OCMVerify([updateWeatherCommand execute:applicationController]);
+        });
+    });
+});
+
+SpecEnd


### PR DESCRIPTION
When the user allows us to always retrieve their location,
we will perform background fetches when the system allows.
If they deny this and set it to "when in use",
the app will disable background fetch and continue to work.

- Switch location services from when in use to always
- Enabled background fetch
- Fetch and cache weather update in background

https://trello.com/c/dNA4MJGZ/5-background-fetching