### PR TITLE
Add TRTemperatureComparisonFormatter+initWithDate for context aware comparisons

### DIFF
--- a/Tropos.xcodeproj/project.pbxproj
+++ b/Tropos.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		130C4C29D1C62D52D0767A6B /* Main.storyboard in Sources */ = {isa = PBXBuildFile; fileRef = E59B090E67C8BD269D3CD9DB /* Main.storyboard */; };
+		23AB769C1B4222830083EC14 /* TRTemperatureComparisonFormatterSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 23AB769B1B4222830083EC14 /* TRTemperatureComparisonFormatterSpec.m */; };
 		46660A27B04F4C7B78A7920F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 436D9431497525313B32E225 /* Foundation.framework */; };
 		4D0A5C381A3A27510084C41E /* TRForecastController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D0A5C371A3A27510084C41E /* TRForecastController.m */; };
 		4D0A5C3D1A3A53DD0084C41E /* CWForecastDetailView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4D0A5C3C1A3A53DD0084C41E /* CWForecastDetailView.xib */; };
@@ -89,6 +90,7 @@
 		0CC72A6E0EE525537F241EB7 /* TRAppDelegate.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = TRAppDelegate.h; sourceTree = "<group>"; };
 		1CDD2312F1EF05277F045E15 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		22FE01C01AF3F5550085B494 /* Secrets.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Secrets.h; sourceTree = "<group>"; };
+		23AB769B1B4222830083EC14 /* TRTemperatureComparisonFormatterSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TRTemperatureComparisonFormatterSpec.m; path = Formatters/TRTemperatureComparisonFormatterSpec.m; sourceTree = "<group>"; };
 		2763A13D16F7B234E309A37C /* Pods-unit_tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-unit_tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-unit_tests/Pods-unit_tests.release.xcconfig"; sourceTree = "<group>"; };
 		2853082980109C89B8F07D3C /* main.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		2CA708068A67D7E761D29251 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
@@ -198,7 +200,6 @@
 		DED70296CC99B4AAD0DE42BD /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		E2B218FB5F097AAE3080F4DD /* UnitTests-Prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UnitTests-Prefix.pch"; sourceTree = "<group>"; };
 		E59B090E67C8BD269D3CD9DB /* Main.storyboard */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
-		E799194B1ACEE75C00A5600C /* Secrets.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Secrets.h; sourceTree = "<group>"; };
 		E7A895521AFD11AA0023205B /* TRApplicationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TRApplicationController.h; sourceTree = "<group>"; };
 		E7A895531AFD11AA0023205B /* TRApplicationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRApplicationController.m; sourceTree = "<group>"; };
 		E7A8955B1AFD1CAA0023205B /* TRWeatherUpdateCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TRWeatherUpdateCache.h; sourceTree = "<group>"; };
@@ -261,6 +262,14 @@
 				2CA708068A67D7E761D29251 /* Pods.debug.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		23AB769A1B4222640083EC14 /* Formatters */ = {
+			isa = PBXGroup;
+			children = (
+				23AB769B1B4222830083EC14 /* TRTemperatureComparisonFormatterSpec.m */,
+			);
+			name = Formatters;
 			sourceTree = "<group>";
 		};
 		301CF0A99B4C5FAECDB23D75 /* Resources */ = {
@@ -476,6 +485,7 @@
 		D487E2F8148F4F831FE4B216 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				23AB769A1B4222640083EC14 /* Formatters */,
 				C2E44CFD1A3B7C14009CC844 /* TRTemperatureSpec.m */,
 				4D9CA35C1A5C7672009E24DD /* TRBearingFormatterSpec.m */,
 				4DA79AC01A68806600C3539D /* UIColor_TRTemperatureColorsSpec.m */,
@@ -828,6 +838,7 @@
 				E7E4A3A21B069BB500F489E3 /* TRWeatherUpdateCacheSpec.m in Sources */,
 				C2E44CFE1A3B7C14009CC844 /* TRTemperatureSpec.m in Sources */,
 				4DA79AC11A68806600C3539D /* UIColor_TRTemperatureColorsSpec.m in Sources */,
+				23AB769C1B4222830083EC14 /* TRTemperatureComparisonFormatterSpec.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tropos/Formatters/TRTemperatureComparisonFormatter.h
+++ b/Tropos/Formatters/TRTemperatureComparisonFormatter.h
@@ -2,6 +2,7 @@
 
 @interface TRTemperatureComparisonFormatter : NSObject
 
-+ (NSString *)localizedStringFromComparison:(TRTemperatureComparison)comparison adjective:(NSString *__autoreleasing *)adjective precipitation:(NSString *)precipitation;
+- (instancetype)initWithDate:(NSDate *)date;
+- (NSString *)localizedStringFromComparison:(TRTemperatureComparison)comparison adjective:(NSString *__autoreleasing *)adjective precipitation:(NSString *)precipitation;
 
 @end

--- a/Tropos/Formatters/TRTemperatureComparisonFormatter.m
+++ b/Tropos/Formatters/TRTemperatureComparisonFormatter.m
@@ -7,9 +7,25 @@ typedef NS_ENUM(NSUInteger, TRTimeOfDay) {
     TRTimeOfDayNight
 };
 
+@interface TRTemperatureComparisonFormatter ()
+
+@property (strong, nonatomic) NSDate *date;
+
+@end
+
 @implementation TRTemperatureComparisonFormatter
 
-+ (NSString *)localizedStringFromComparison:(TRTemperatureComparison)comparison adjective:(NSString *__autoreleasing *)adjective precipitation:(NSString *)precipitation
+- (instancetype)initWithDate:(NSDate *)date
+{
+    self = [super init];
+    if (!self) { return nil; }
+
+    self.date = date;
+
+    return self;
+}
+
+- (NSString *)localizedStringFromComparison:(TRTemperatureComparison)comparison adjective:(NSString *__autoreleasing *)adjective precipitation:(NSString *)precipitation
 {
     NSString *formatString = (comparison == TRTemperatureComparisonSame)? NSLocalizedString(@"SameTemperatureFormat", nil) : NSLocalizedString(@"DifferentTemperatureFormat", nil);
     *adjective = [self localizedAdjectiveForTemperatureComparison:comparison];
@@ -19,7 +35,7 @@ typedef NS_ENUM(NSUInteger, TRTimeOfDay) {
 
 #pragma mark - Private Methods
 
-+ (NSString *)localizedAdjectiveForTemperatureComparison:(TRTemperatureComparison)comparison
+- (NSString *)localizedAdjectiveForTemperatureComparison:(TRTemperatureComparison)comparison
 {
     switch (comparison) {
         case TRTemperatureComparisonHotter:
@@ -35,7 +51,7 @@ typedef NS_ENUM(NSUInteger, TRTimeOfDay) {
     }
 }
 
-+ (NSString *)localizedCurrentTimeOfDay
+- (NSString *)localizedCurrentTimeOfDay
 {
     switch ([self timeOfDay]) {
         case TRTimeOfDayNight:
@@ -51,7 +67,7 @@ typedef NS_ENUM(NSUInteger, TRTimeOfDay) {
     }
 }
 
-+ (NSString *)localizedPreviousTimeOfDay
+- (NSString *)localizedPreviousTimeOfDay
 {
     switch ([self timeOfDay]) {
         case TRTimeOfDayNight:
@@ -67,9 +83,9 @@ typedef NS_ENUM(NSUInteger, TRTimeOfDay) {
     }
 }
 
-+ (TRTimeOfDay)timeOfDay;
+- (TRTimeOfDay)timeOfDay
 {
-    NSDateComponents *dateComponents = [[self calendar] components:NSCalendarUnitHour fromDate:[NSDate date]];
+    NSDateComponents *dateComponents = [[[self class] calendar] components:NSCalendarUnitHour fromDate:self.date];
 
     if (dateComponents.hour < 4) {
         return TRTimeOfDayNight;

--- a/Tropos/ViewModels/TRWeatherViewModel.m
+++ b/Tropos/ViewModels/TRWeatherViewModel.m
@@ -50,7 +50,8 @@
     TRTemperatureComparison comparison = [self.weatherUpdate.currentTemperature comparedTo:self.weatherUpdate.yesterdaysTemperature];
 
     NSString *adjective;
-    NSString *comparisonString = [TRTemperatureComparisonFormatter localizedStringFromComparison:comparison adjective:&adjective  precipitation: self.precipitationDescription];
+    TRTemperatureComparisonFormatter *comparisonFormatter = [[TRTemperatureComparisonFormatter alloc] initWithDate:self.weatherUpdate.date];
+    NSString *comparisonString = [comparisonFormatter localizedStringFromComparison:comparison adjective:&adjective  precipitation: self.precipitationDescription];
 
     NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:comparisonString];
     [attributedString setFont:[UIFont defaultUltraLightFontOfSize:26]];

--- a/UnitTests/Tests/Formatters/TRTemperatureComparisonFormatterSpec.m
+++ b/UnitTests/Tests/Formatters/TRTemperatureComparisonFormatterSpec.m
@@ -1,0 +1,34 @@
+#import "TRTemperatureComparisonFormatter.h"
+
+@interface TRTemperatureComparisonFormatter (Tests)
+
++ (NSCalendar *)calendar;
+
+@end
+
+SpecBegin(TRTemperatureComparisonFormatter)
+
+NSDate* (^dateFromString) (NSString*) = ^NSDate* (NSString *dateString) {
+    NSDateFormatter *dateFormatter = [NSDateFormatter new];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss zzz"];
+    return [dateFormatter dateFromString:dateString];
+};
+
+describe(@"TRTemperatureComparisonFormatter", ^{
+    describe(@"localizedStringFromComparison:adjective:precipitation", ^{
+        it(@"bases the time of day off of the date", ^{
+            [[TRTemperatureComparisonFormatter calendar] setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
+            NSString *adjective;
+            NSDate *date = dateFromString(@"2015-05-15 22:00:00 UTC");
+            TRTemperatureComparisonFormatter *formatter = [[TRTemperatureComparisonFormatter alloc] initWithDate:date];
+
+            NSString *stringComparison = [formatter localizedStringFromComparison:TRTemperatureComparisonSame
+                                                              adjective:&adjective
+                                                          precipitation:@""];
+
+            expect(stringComparison).to.equal(@"It's the same tonight as last night.");
+        });
+    });
+});
+
+SpecEnd


### PR DESCRIPTION
There was a bug where comparisons
shown from the cache would show inaccurate text
because it wasn't using the date from the cache.

Ex:
If the date was cached in the AM and you open the app in the afternoon it might say,
"Last updated 8:00AM, It's the same this afternoon as yesterday afternoon."
when it should say,
"Last updated 8:00AM, It's the same this morning as yesterday morning."

This PR has the comparison be initialized with a date
that it uses when checking the time of day.

I chose to switch from a class method to instance method
so that I didn't have to pass the date
through a chain of class methods.