### PR TITLE
TRTemperatureComparison+localizedStringFromComparison accepts a date

### DIFF
--- a/Tropos.xcodeproj/project.pbxproj
+++ b/Tropos.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		CE5D7F3B45F980082E1BCA30 /* LaunchScreen.xib in Sources */ = {isa = PBXBuildFile; fileRef = B6D58F8AA6976EA1B35682B7 /* LaunchScreen.xib */; };
 		CFC0721C2D9EFFD3C3AE11A7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 059D0BDDF8DCE56549A4C9C6 /* Images.xcassets */; };
 		D7DD1B8AD495AFA4EC1CEFF9 /* TRAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = A6B1ADBC73A8A2EF7FB4E257 /* TRAppDelegate.m */; };
+		E74676A81B8B76620012AD51 /* TRTemperatureComparisonFormatterSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = E74676A71B8B76620012AD51 /* TRTemperatureComparisonFormatterSpec.m */; };
 		E7A895541AFD11AA0023205B /* TRApplicationController.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A895531AFD11AA0023205B /* TRApplicationController.m */; };
 		E7A8955D1AFD1CAA0023205B /* TRWeatherUpdateCache.m in Sources */ = {isa = PBXBuildFile; fileRef = E7A8955C1AFD1CAA0023205B /* TRWeatherUpdateCache.m */; };
 		E7B3B9271B34EDFE00BDD5A4 /* TRApplicationControllerSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = E7B3B9261B34EDFE00BDD5A4 /* TRApplicationControllerSpec.m */; };
@@ -205,6 +206,7 @@
 		DED70296CC99B4AAD0DE42BD /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		E2B218FB5F097AAE3080F4DD /* UnitTests-Prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UnitTests-Prefix.pch"; sourceTree = "<group>"; };
 		E59B090E67C8BD269D3CD9DB /* Main.storyboard */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
+		E74676A71B8B76620012AD51 /* TRTemperatureComparisonFormatterSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TRTemperatureComparisonFormatterSpec.m; path = Formatters/TRTemperatureComparisonFormatterSpec.m; sourceTree = "<group>"; };
 		E7A895521AFD11AA0023205B /* TRApplicationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TRApplicationController.h; sourceTree = "<group>"; };
 		E7A895531AFD11AA0023205B /* TRApplicationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRApplicationController.m; sourceTree = "<group>"; };
 		E7A8955B1AFD1CAA0023205B /* TRWeatherUpdateCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TRWeatherUpdateCache.h; sourceTree = "<group>"; };
@@ -269,6 +271,14 @@
 				2CA708068A67D7E761D29251 /* Pods.debug.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		234BD0111B46419F00D5AEC5 /* Formatters */ = {
+			isa = PBXGroup;
+			children = (
+				E74676A71B8B76620012AD51 /* TRTemperatureComparisonFormatterSpec.m */,
+			);
+			name = Formatters;
 			sourceTree = "<group>";
 		};
 		301CF0A99B4C5FAECDB23D75 /* Resources */ = {
@@ -494,6 +504,7 @@
 			isa = PBXGroup;
 			children = (
 				6D0F13661B433521001685BA /* Models */,
+				234BD0111B46419F00D5AEC5 /* Formatters */,
 				4D9CA35C1A5C7672009E24DD /* TRBearingFormatterSpec.m */,
 				4DA79AC01A68806600C3539D /* UIColor_TRTemperatureColorsSpec.m */,
 				E7E8D6021ACF0B9700BD8364 /* TRWeatherUpdateSpec.m */,
@@ -859,6 +870,7 @@
 				6D8ACB381B443037003087A7 /* Temperature.swift in Sources */,
 				6D0F13681B43353D001685BA /* PrecipitationSpec.swift in Sources */,
 				6D0F13691B4335FE001685BA /* Precipitation.swift in Sources */,
+				E74676A81B8B76620012AD51 /* TRTemperatureComparisonFormatterSpec.m in Sources */,
 				E7E8D6031ACF0B9700BD8364 /* TRWeatherUpdateSpec.m in Sources */,
 				E7B3B9271B34EDFE00BDD5A4 /* TRApplicationControllerSpec.m in Sources */,
 				4D9CA35D1A5C7672009E24DD /* TRBearingFormatterSpec.m in Sources */,

--- a/Tropos/Formatters/TRTemperatureComparisonFormatter.h
+++ b/Tropos/Formatters/TRTemperatureComparisonFormatter.h
@@ -1,7 +1,5 @@
-#import "Tropos-Swift.h"
-
 @interface TRTemperatureComparisonFormatter : NSObject
 
-+ (NSString *)localizedStringFromComparison:(TemperatureComparison)comparison adjective:(NSString *__autoreleasing *)adjective precipitation:(NSString *)precipitation;
++ (NSString *)localizedStringFromComparison:(TemperatureComparison)comparison adjective:(NSString *__autoreleasing *)adjective precipitation:(NSString *)precipitation date:(NSDate *)date;
 
 @end

--- a/Tropos/Formatters/TRTemperatureComparisonFormatter.m
+++ b/Tropos/Formatters/TRTemperatureComparisonFormatter.m
@@ -1,3 +1,4 @@
+#import "Tropos-Swift.h"
 #import "TRTemperatureComparisonFormatter.h"
 
 typedef NS_ENUM(NSUInteger, TRTimeOfDay) {
@@ -9,12 +10,12 @@ typedef NS_ENUM(NSUInteger, TRTimeOfDay) {
 
 @implementation TRTemperatureComparisonFormatter
 
-+ (NSString *)localizedStringFromComparison:(TemperatureComparison)comparison adjective:(NSString *__autoreleasing *)adjective precipitation:(NSString *)precipitation
++ (NSString *)localizedStringFromComparison:(TemperatureComparison)comparison adjective:(NSString *__autoreleasing *)adjective precipitation:(NSString *)precipitation date:(NSDate *)date
 {
     NSString *formatString = (comparison == TemperatureComparisonSame)? NSLocalizedString(@"SameTemperatureFormat", nil) : NSLocalizedString(@"DifferentTemperatureFormat", nil);
     *adjective = [self localizedAdjectiveForTemperatureComparison:comparison];
 
-    return [NSString stringWithFormat:formatString, *adjective, [self localizedCurrentTimeOfDay], [self localizedPreviousTimeOfDay], precipitation];
+    return [NSString stringWithFormat:formatString, *adjective, [self localizedCurrentTimeOfDayForDate:date], [self localizedPreviousTimeOfDayForDate:date], precipitation];
 }
 
 #pragma mark - Private Methods
@@ -35,9 +36,9 @@ typedef NS_ENUM(NSUInteger, TRTimeOfDay) {
     }
 }
 
-+ (NSString *)localizedCurrentTimeOfDay
++ (NSString *)localizedCurrentTimeOfDayForDate:(NSDate *)date
 {
-    switch ([self timeOfDay]) {
+    switch ([self timeOfDayForDate:date]) {
         case TRTimeOfDayNight:
             return NSLocalizedString(@"Tonight", nil);
         case TRTimeOfDayMorning:
@@ -51,9 +52,9 @@ typedef NS_ENUM(NSUInteger, TRTimeOfDay) {
     }
 }
 
-+ (NSString *)localizedPreviousTimeOfDay
++ (NSString *)localizedPreviousTimeOfDayForDate:(NSDate *)date
 {
-    switch ([self timeOfDay]) {
+    switch ([self timeOfDayForDate:date]) {
         case TRTimeOfDayNight:
             return NSLocalizedString(@"LastNight", nil);
         case TRTimeOfDayMorning:
@@ -67,9 +68,9 @@ typedef NS_ENUM(NSUInteger, TRTimeOfDay) {
     }
 }
 
-+ (TRTimeOfDay)timeOfDay;
++ (TRTimeOfDay)timeOfDayForDate:(NSDate *)date;
 {
-    NSDateComponents *dateComponents = [[self calendar] components:NSCalendarUnitHour fromDate:[NSDate date]];
+    NSDateComponents *dateComponents = [[self calendar] components:NSCalendarUnitHour fromDate:date];
 
     if (dateComponents.hour < 4) {
         return TRTimeOfDayNight;

--- a/Tropos/ViewModels/TRWeatherViewModel.m
+++ b/Tropos/ViewModels/TRWeatherViewModel.m
@@ -50,7 +50,7 @@
     TemperatureComparison comparison = [self.weatherUpdate.currentTemperature comparedTo:self.weatherUpdate.yesterdaysTemperature];
 
     NSString *adjective;
-    NSString *comparisonString = [TRTemperatureComparisonFormatter localizedStringFromComparison:comparison adjective:&adjective  precipitation: self.precipitationDescription];
+    NSString *comparisonString = [TRTemperatureComparisonFormatter localizedStringFromComparison:comparison adjective:&adjective  precipitation: self.precipitationDescription date:self.weatherUpdate.date];
 
     NSMutableAttributedString *attributedString = [[NSMutableAttributedString alloc] initWithString:comparisonString];
     [attributedString setFont:[UIFont defaultUltraLightFontOfSize:26]];

--- a/UnitTests/Tests/Formatters/TRTemperatureComparisonFormatterSpec.m
+++ b/UnitTests/Tests/Formatters/TRTemperatureComparisonFormatterSpec.m
@@ -1,0 +1,34 @@
+#import "UnitTests-Swift.h"
+#import "TRTemperatureComparisonFormatter.h"
+
+@interface TRTemperatureComparisonFormatter (Tests)
+
++ (NSCalendar *)calendar;
+
+@end
+
+SpecBegin(TRTemperatureComparisonFormatter)
+
+NSDate* (^dateFromString) (NSString*) = ^NSDate *(NSString *dateString) {
+    NSDateFormatter *dateFormatter = [NSDateFormatter new];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss zzz"];
+    return [dateFormatter dateFromString:dateString];
+};
+
+describe(@"TRTemperatureComparisonFormatter", ^{
+    describe(@"localizedStringFromComparison:adjective:precipitation", ^{
+        it(@"bases the time of day off of the date", ^{
+            [[TRTemperatureComparisonFormatter calendar] setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
+            NSString *adjective;
+            NSDate *date = dateFromString(@"2015-05-15 22:00:00 UTC");
+            NSString *stringComparison = [TRTemperatureComparisonFormatter localizedStringFromComparison:TemperatureComparisonSame
+                                                                                               adjective:&adjective
+                                                                                           precipitation:@""
+                                                                                                    date:date];
+
+            expect(stringComparison).to.equal(@"It's the same tonight as last night.");
+        });
+    });
+});
+
+SpecEnd


### PR DESCRIPTION
There was a bug in where comparisons
shown from the cache would show inaccurate text
because it wasn't using the date from the cache.

Ex:
If the date was cached in the AM and you open the app in the afternoon it might say,
"Last updated 8:00AM, It's the same this afternoon as yesterday afternoon."
when it should say,
"Last updated 8:00AM, It's the same this morning as yesterday morning."

This PR has the comparison be initialized with a date
that it uses when checking the time of day.

I chose to switch from a class method to instance method
so that I didn't have to pass the date
through a chain of class methods.

https://trello.com/c/IeLJK4C8/36-temperature-comparison-text-not-taking-cached-date-into-account