### PR TITLE
Fix bug incorrectly displaying the chance of rain

### DIFF
--- a/Tropos/Models/Precipitation.swift
+++ b/Tropos/Models/Precipitation.swift
@@ -10,7 +10,7 @@ import Foundation
 
     var chance: PrecipitationChance {
         switch probability {
-        case _ where probability > 30.0: return .Good
+        case _ where probability > 0.3: return .Good
         case _ where probability > 0: return .Slight
         default: return .None
         }

--- a/Tropos/Models/TRWeatherUpdate.m
+++ b/Tropos/Models/TRWeatherUpdate.m
@@ -38,17 +38,17 @@
     self.city = placemark.locality;
     self.state = placemark.administrativeArea;
 
-    NSDictionary *todaysConditions = currentConditionsJSON[@"currently"];
+    NSDictionary *currentConditions = currentConditionsJSON[@"currently"];
     NSDictionary *yesterdaysConditions = yesterdaysConditionsJSON[@"currently"];
     NSDictionary *todaysForecast = [currentConditionsJSON[@"daily"][@"data"] firstObject];
 
     self.precipitationPercentage = [todaysForecast[@"precipProbability"] floatValue];
     self.precipitationType = todaysForecast[@"precipType"] ? todaysForecast[@"precipType"] : @"rain";
-    self.conditionsDescription = todaysConditions[@"icon"];
-    [self updateCurrentTemperaturesWithConditions:todaysConditions withForecast:todaysForecast];
+    self.conditionsDescription = currentConditions[@"icon"];
+    [self updateCurrentTemperaturesWithConditions:currentConditions withForecast:todaysForecast];
     self.yesterdaysTemperature = [[Temperature alloc] initWithFahrenheitValue:[yesterdaysConditions[@"temperature"] integerValue]];
-    self.windBearing = [todaysConditions[@"windBearing"] floatValue];
-    self.windSpeed = [todaysConditions[@"windSpeed"] floatValue];
+    self.windBearing = [currentConditions[@"windBearing"] floatValue];
+    self.windSpeed = [currentConditions[@"windSpeed"] floatValue];
     self.date = [NSDate date];
 
     NSMutableArray *dailyForecasts = [NSMutableArray array];

--- a/UnitTests/Tests/PrecipitationSpec.swift
+++ b/UnitTests/Tests/PrecipitationSpec.swift
@@ -12,12 +12,12 @@ class PrecipitationSpec: QuickSpec {
                 }
 
                 it("returns slight for 1 - 30% chance of precipitation") {
-                    let precipitation = Precipitation(probability: 20.0, type: "")
+                    let precipitation = Precipitation(probability: 0.2, type: "")
                     expect(precipitation.chance).to(equal(PrecipitationChance.Slight))
                 }
 
                 it("returns good for chance greater than 30% of precipitation") {
-                    let precipitation = Precipitation(probability: 70.0, type: "")
+                    let precipitation = Precipitation(probability: 0.7, type: "")
                     expect(precipitation.chance).to(equal(PrecipitationChance.Good))
                 }
             }


### PR DESCRIPTION
forecast.io gives us the percentage chance of rain from 0...1, not 0...100 (as
our code previously assumed)

* Also renames the `todaysConditions` variable to `currentConditions` for clarity

Trello: https://trello.com/c/N3qcunas/35-reports-100-precipitation-as-sight-chance-of-rain

Pair: Adam Sharp