### PR TITLE
Update dependencies to fix bitcode linker errors when building for device

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,8 +1,8 @@
 platform :ios, '8.0'
 
-pod 'HockeySDK', '~> 3.6.2', :inhibit_warnings => true
+pod 'HockeySDK', '~> 3.6', :inhibit_warnings => true
 pod 'ReactiveCocoa', '~> 2.4.7'
-pod 'Mixpanel', '~> 2.7.2', :inhibit_warnings => true
+pod 'Mixpanel', '~> 2.7', :inhibit_warnings => true
 
 target :unit_tests, :exclusive => true do
   link_with 'UnitTests'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,9 +1,11 @@
 PODS:
   - Expecta (1.0.3)
-  - HockeySDK (3.6.4)
-  - Mixpanel (2.7.4):
-    - Mixpanel/MPCategoryHelpers (= 2.7.4)
-  - Mixpanel/MPCategoryHelpers (2.7.4)
+  - HockeySDK (3.8.6):
+    - HockeySDK/AllFeaturesLib (= 3.8.6)
+  - HockeySDK/AllFeaturesLib (3.8.6)
+  - Mixpanel (2.9.6):
+    - Mixpanel/Mixpanel (= 2.9.6)
+  - Mixpanel/Mixpanel (2.9.6)
   - OCMock (3.1.5)
   - OHHTTPStubs (4.3.0):
     - OHHTTPStubs/Default (= 4.3.0)
@@ -29,8 +31,8 @@ PODS:
 
 DEPENDENCIES:
   - Expecta
-  - HockeySDK (~> 3.6.2)
-  - Mixpanel (~> 2.7.2)
+  - HockeySDK (~> 3.6)
+  - Mixpanel (~> 2.7)
   - OCMock
   - OHHTTPStubs
   - ReactiveCocoa (~> 2.4.7)
@@ -38,8 +40,8 @@ DEPENDENCIES:
 
 SPEC CHECKSUMS:
   Expecta: 9d1bff6c8b0eeee73a166a2ee898892478927a15
-  HockeySDK: c07cdd580296737edcd0963e292c19885a53f563
-  Mixpanel: 33353c8fb319bb37b613eb7dbf02a2b2ac04f92c
+  HockeySDK: ab68303eec6680f6b539de65d747742dd276e934
+  Mixpanel: 048a9f2512ac1bb8bfdecf719da024873f50a9c2
   OCMock: 4c2925291f80407c3738dd1db14d21d0cc278864
   OHHTTPStubs: 0aec5755528693a165bd616cb79f69387de306a8
   ReactiveCocoa: eb38dee0a0e698f73a9b25e5c1faea2bb4c79240

--- a/Resources/Other-Sources/Settings.bundle/Acknowledgements.plist
+++ b/Resources/Other-Sources/Settings.bundle/Acknowledgements.plist
@@ -19,7 +19,7 @@
 The Hockey SDK is provided under the following license:
 
     The MIT License
-    Copyright (c) 2012-2015 HockeyApp, Bit Stadium GmbH.
+    Copyright (c) Microsoft Corporation.
     All rights reserved.
 	
     Permission is hereby granted, free of charge, to any person
@@ -405,25 +405,6 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-================================================================================
-
-libMPCategoryHelpers.a (c) Mixpanel, Inc. 2014.
-
-Mixpanel grants you a limited, non-exclusive, non-transferable,
-non-sublicenseable, revocable license to use the Software solely for your
-internal use.  You may not commercialize this Software for the benefit of any
-third party.  You may not decompile, disassemble, reverse engineer or otherwise
-attempt to obtain or perceive the source code from which any software component
-of the Software are compiled or interpreted, and you acknowledge that nothing
-herein will be construed to grant you any right to obtain or use such code nor
-create any derivative product from any of the foregoing, except with the prior
-written consent of Mixpanel.  Any dispute arising hereunder shall be submitted
-to confidential binding arbitration in the County and City of San Francisco,
-California for the maximum judgment enforceable, except that to the extent you
-have in any manner violated or threatened to violate Mixplanel&#8217;s intellectual
-property rights, Mixpanel may seek injunctive or other appropriate relief in
-any state or federal court in the State of California.
 </string>
 			<key>Title</key>
 			<string>Mixpanel</string>

--- a/bin/archive
+++ b/bin/archive
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eo pipefail
+
+xcodebuild archive \
+  -workspace Tropos.xcworkspace \
+  -scheme Tropos \
+  -archivePath $PWD/build/Tropos.xcarchive \
+  SYMROOT=$PWD/build \
+| xcpretty -c

--- a/bin/archive
+++ b/bin/archive
@@ -2,6 +2,27 @@
 
 set -eo pipefail
 
+if [ "$CI" = "true" -a -z "$DISABLE_CODE_SIGNING" ]; then
+  DISABLE_CODE_SIGNING="true"
+fi
+
+if [ "$DISABLE_CODE_SIGNING" = "true" ]; then
+  echo >&2 "Running with code signing disabled (set DISABLE_CODE_SIGNING=false to enable)"
+
+  code_sign_xcconfig=$(mktemp /tmp/tropos-bin-archive.XXXXXX)
+  trap "rm -f '$code_sign_xcconfig'" INT TERM HUP EXIT
+
+  cat >"$code_sign_xcconfig" <<EOF
+CODE_SIGNING_REQUIRED=NO
+CODE_SIGN_ENTITLEMENTS=
+CODE_SIGN_IDENTITY=
+EOF
+
+  export XCODE_XCCONFIG_FILE="$code_sign_xcconfig"
+else
+  echo >&2 "Running with code signing enabled (set DISABLE_CODE_SIGNING=true to disable)"
+fi
+
 xcodebuild archive \
   -workspace Tropos.xcworkspace \
   -scheme Tropos \

--- a/circle.yml
+++ b/circle.yml
@@ -10,3 +10,4 @@ dependencies:
 test:
   override:
     - bin/test
+    - bin/archive


### PR DESCRIPTION
This change updates both Mixpanel and HockeySDK to new minor versions that include support for bitcode.