### PR TITLE
Use GMT offset as Courier channel name

### DIFF
--- a/Tropos.xcodeproj/project.pbxproj
+++ b/Tropos.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		A11D71D31CD73697000EB4A3 /* Courier.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A11D71D21CD73697000EB4A3 /* Courier.framework */; };
 		A11D71D51CD73751000EB4A3 /* CourierClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11D71D41CD73751000EB4A3 /* CourierClient.swift */; };
 		A19A00DA1D06ADB600338426 /* TRCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = A19A00D91D06ADB600338426 /* TRCommand.m */; };
+		A1BBE84F1D07D2F900A9631A /* CourierClientSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BBE84D1D07D2C500A9631A /* CourierClientSpec.swift */; };
 		A1FC9ECD1CFE935500E62618 /* CourierClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11D71D41CD73751000EB4A3 /* CourierClient.swift */; };
 		A1FC9ED21CFEA23B00E62618 /* TroposCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A552EEF1CC7C8F8008C7298 /* TroposCore.framework */; };
 		A1FC9ED31CFEA23B00E62618 /* TroposCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4A552EEF1CC7C8F8008C7298 /* TroposCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -303,6 +304,7 @@
 		A11D71D41CD73751000EB4A3 /* CourierClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourierClient.swift; sourceTree = "<group>"; };
 		A19A00D81D06ADB600338426 /* TRCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TRCommand.h; sourceTree = "<group>"; };
 		A19A00D91D06ADB600338426 /* TRCommand.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TRCommand.m; sourceTree = "<group>"; };
+		A1BBE84D1D07D2C500A9631A /* CourierClientSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourierClientSpec.swift; sourceTree = "<group>"; };
 		A1FC9ECE1CFE937900E62618 /* UnitTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UnitTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		A6B1ADBC73A8A2EF7FB4E257 /* TRAppDelegate.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = TRAppDelegate.m; sourceTree = "<group>"; };
 		B1E75D271B6E8ADC007B03F9 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -772,6 +774,7 @@
 			isa = PBXGroup;
 			children = (
 				E7B3B9261B34EDFE00BDD5A4 /* TRApplicationControllerSpec.m */,
+				A1BBE84D1D07D2C500A9631A /* CourierClientSpec.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -1246,6 +1249,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A1FC9ECD1CFE935500E62618 /* CourierClient.swift in Sources */,
+				A1BBE84F1D07D2F900A9631A /* CourierClientSpec.swift in Sources */,
 				E7B3B9271B34EDFE00BDD5A4 /* TRApplicationControllerSpec.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tropos/Sources/Controllers/CourierClient.swift
+++ b/Tropos/Sources/Controllers/CourierClient.swift
@@ -1,7 +1,20 @@
 import Courier
 
+@objc protocol TimeZone {
+    var secondsFromGMT: Int { get }
+}
+extension NSTimeZone: TimeZone {}
+
 @objc(TRCourierClient) final class CourierClient: NSObject {
     private let instance: Courier
+
+    class func channelNameForTimeZone(timeZone: TimeZone) -> String {
+        let seconds = timeZone.secondsFromGMT
+        let sign = seconds < 0 ? "minus" : "plus"
+        let hours = abs(seconds) / 3600
+        let minutes = (abs(seconds) % 3600) / 60
+        return String(format: "%@ %02d%02d", sign, hours, minutes)
+    }
 
     init(apiToken: String) {
         let environment: Environment

--- a/Tropos/Sources/Controllers/TRApplicationController.m
+++ b/Tropos/Sources/Controllers/TRApplicationController.m
@@ -81,7 +81,8 @@
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     NSString *formerChannelKey = @"CourierChannel";
 
-    NSString *channel = [[NSTimeZone localTimeZone] name];
+    NSTimeZone *timeZone = [NSTimeZone localTimeZone];
+    NSString *channel = [TRCourierClient channelNameForTimeZone:timeZone];
 
     NSString *formerChannel = [userDefaults stringForKey:formerChannelKey];
     if (formerChannel && ![channel isEqualToString:formerChannel]) {

--- a/Tropos/Specs/Controllers/CourierClientSpec.swift
+++ b/Tropos/Specs/Controllers/CourierClientSpec.swift
@@ -1,0 +1,42 @@
+import Quick
+import Nimble
+@testable import Tropos
+
+class CourierClientSpec: QuickSpec {
+    override func spec() {
+        describe("channelNameForTimeZone") {
+            it("returns plus 0200 for +7200 seconds from GMT") {
+                let timeZone = FakeTimeZone(secondsFromGMT: 7200)
+
+                let channel = CourierClient.channelNameForTimeZone(timeZone)
+
+                expect(channel) == "plus 0200"
+            }
+
+            it("returns minus 0700 for -25200 seconds from GMT") {
+                let timeZone = FakeTimeZone(secondsFromGMT: -25200)
+
+                let channel = CourierClient.channelNameForTimeZone(timeZone)
+
+                expect(channel) == "minus 0700"
+            }
+
+            it("returns plus 0230 for +9000 seconds from GMT") {
+
+                let timeZone = FakeTimeZone(secondsFromGMT: 9000)
+
+                let channel = CourierClient.channelNameForTimeZone(timeZone)
+
+                expect(channel) == "plus 0230"
+            }
+        }
+    }
+}
+
+@objc class FakeTimeZone: NSObject, TimeZone {
+    var secondsFromGMT: Int
+
+    init(secondsFromGMT: Int) {
+        self.secondsFromGMT = secondsFromGMT
+    }
+}

--- a/Tropos/Specs/Controllers/TRApplicationControllerSpec.m
+++ b/Tropos/Specs/Controllers/TRApplicationControllerSpec.m
@@ -79,7 +79,7 @@ describe(@"TRApplicationController", ^{
             NSData *deviceToken = [NSData new];
             [applicationController subscribeToNotificationsWithDeviceToken:deviceToken];
 
-            NSString *channel = [[NSTimeZone localTimeZone] name];
+            NSString *channel = [TRCourierClient channelNameForTimeZone:[NSTimeZone localTimeZone]];
             OCMVerify([courier subscribeToChannel:channel withToken:deviceToken]);
         });
 
@@ -88,7 +88,7 @@ describe(@"TRApplicationController", ^{
             TRApplicationController *applicationController = [TRApplicationController new];
             applicationController.courier = courier;
             NSTimeZone *initialTimeZone = [NSTimeZone timeZoneWithAbbreviation:@"CEST"];
-            NSString *expectedChannel = initialTimeZone.name;
+            NSString *expectedChannel = [TRCourierClient channelNameForTimeZone: initialTimeZone];
             NSData *deviceToken = [NSData new];
 
             inTimeZone(initialTimeZone, ^{


### PR DESCRIPTION
This partially fixes the issue where certain time zones will never receive push notifications because the time zone names used by Rails are different from those used by iOS (See thoughtbot/Tropos#185 for more information)

This fixes it by not using the names, but the relative offset from UTC as the channel name. Currently we subscribe to us-pacific when the iOS time zone is set to San Francisco.

This PR changes it to subscribe to the channel minus-0700 instead. This is a more reliable way of identifying time zones across platforms.