### PR TITLE
Fix CI warnings and Swift 2.3 compatibility

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v6.0.1"
-github "Quick/Quick" "v1.1.0"
+github "Quick/Nimble" "v4.1.0"
+github "Quick/Quick" "v0.9.3"
 github "thoughtbot/courier-ios" "v0.2.0"

--- a/Core/Specs/Models/WeatherUpdateCacheSpec.swift
+++ b/Core/Specs/Models/WeatherUpdateCacheSpec.swift
@@ -11,7 +11,7 @@ private var testCachesDirectory: NSURL {
 }
 
 private var testWeatherUpdateURL: NSURL {
-    return testCachesDirectory.URLByAppendingPathComponent(testCacheFileName)
+    return testCachesDirectory.URLByAppendingPathComponent(testCacheFileName)!
 }
 
 private func resetFilesystem() {

--- a/Tropos/Resources/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Tropos/Resources/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,6 +1,16 @@
 {
   "images" : [
     {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
       "size" : "29x29",
       "idiom" : "iphone",
       "filename" : "Icon-Small.png",
@@ -51,6 +61,16 @@
       "idiom" : "iphone",
       "filename" : "Icon-60@3x.png",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
     },
     {
       "idiom" : "ipad",
@@ -112,6 +132,46 @@
     },
     {
       "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "16x16",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "32x32",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "128x128",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "mac",
+      "size" : "256x256",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "mac",
       "size" : "512x512",
       "scale" : "1x"
     },
@@ -120,11 +180,6 @@
       "idiom" : "mac",
       "filename" : "iTunesArtwork@2x.png",
       "scale" : "2x"
-    },
-    {
-      "idiom" : "car",
-      "size" : "120x120",
-      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Tropos/Sources/Views/TRDailyForecastView.m
+++ b/Tropos/Sources/Views/TRDailyForecastView.m
@@ -15,6 +15,7 @@
 
 - (void)awakeFromNib
 {
+    [super awakeFromNib];
     [[NSBundle mainBundle] loadNibNamed:NSStringFromClass([self class]) owner:self options:nil];
     [self addSubview:self.contentView];
 }

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "7.3"
+    version: "8.2.1"
 
 dependencies:
   override:


### PR DESCRIPTION
This commit does several things, including updating the Xcode version for CI, pinning dependencies to supported versions (i.e. versions that support Swift 2.3), and fixing warnings that were caught as errors.