### PR TITLE
Trigger an update on first launch

### DIFF
--- a/Tropos/Sources/Controllers/TRAppDelegate.m
+++ b/Tropos/Sources/Controllers/TRAppDelegate.m
@@ -34,6 +34,8 @@
     self.window.rootViewController = self.applicationController.rootViewController;
     [self.window makeKeyAndVisible];
 
+    [self.applicationController updateWeather];
+
     return YES;
 }
 


### PR DESCRIPTION
On first launch, the application delegate does not receive `applicationWillEnterForeground:`, so the app was launching to a completely blank screen.