### PR TITLE
Fix a but with precipitation probability

### DIFF
--- a/Core/Sources/Models/WeatherUpdate.swift
+++ b/Core/Sources/Models/WeatherUpdate.swift
@@ -126,7 +126,7 @@ public extension WeatherUpdate {
     }
 
     @objc var precipitationPercentage: Double {
-        return Double(todaysForecast["precipProbability"] as? String ?? "") ?? 0
+        return (todaysForecast["precipProbability"] as? NSNumber)?.doubleValue ?? 0
     }
 
     @objc var windSpeed: Double {


### PR DESCRIPTION
It was casting to the wrong type so the text did not match the icon.

From this:
![simulator screen shot - iphone x - 2018-05-18 at 13 32 07](https://user-images.githubusercontent.com/165531/40249197-3b1c0988-5aa0-11e8-931a-ca0f3084f4b1.png)

To this:
![simulator screen shot - iphone x - 2018-05-18 at 13 22 40](https://user-images.githubusercontent.com/165531/40248982-9ca85d92-5a9f-11e8-81f9-633b01cdf866.png)