### PR TITLE
Add Italian localisation for the Siri Intents

### DIFF
--- a/Sources/Tropos/Resources/it.lproj/Localizable.strings
+++ b/Sources/Tropos/Resources/it.lproj/Localizable.strings
@@ -1,2 +1,3 @@
+"CheckWeatherSuggestedPhrase" = "Controlla previsioni Meteo";
 "CheckingWeather" = "Controllo il Meteo...";
 "UpdateFailed" = "Update non riuscito";

--- a/Sources/TroposIntents/it.lproj/Intents.strings
+++ b/Sources/TroposIntents/it.lproj/Intents.strings
@@ -1,6 +1,5 @@
-"8SKsHj" = "Check weather forecast";
+"8SKsHj" = "Controlla previsioni meteo";
 
 "Hpkcrr" = "${conditionsDescription}";
 
-"RwwC7B" = "Check the current weather forecast";
-
+"RwwC7B" = "Controlla le attuali previsioni meteo";


### PR DESCRIPTION
This PR adds the missing translations for the Italian language in the new Siri shortcut, as requested in #214 
