### PR TITLE
Use brew-bundle to avoid Homebrew build failures

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,4 @@
+# vim: ft=ruby
+
+brew "carthage"
+brew "swiftlint"

--- a/bin/setup
+++ b/bin/setup
@@ -4,8 +4,7 @@ set -e
 
 bundle install
 bundle exec pod install
-brew install carthage 2> /dev/null
-brew install swiftlint 2> /dev/null
+brew bundle
 carthage bootstrap --platform iOS --cache-builds
 
 tropos_secrets="Config/Secrets.h"


### PR DESCRIPTION
`brew install` exits with status 1 if a formula is already installed and a newer version is available. These failures were previously ignored, but commit 5c09cc9a1c6b6d58509266e7fe561530ef5bcb2d caused them to start failing builds on CI.

Introduce a `Brewfile` to manage the Homebrew dependencies for this repo, and use `brew bundle` to install them, which helpfully no longer fails if newer versions are available.