### PR TITLE
Fix weather update becoming unresponsive

### DIFF
--- a/Sources/TroposCore/Controllers/LocationController.swift
+++ b/Sources/TroposCore/Controllers/LocationController.swift
@@ -38,7 +38,10 @@ import Result
 
     public func requestLocation() -> SignalProducer<CLLocation, CLError> {
         return SignalProducer { [locationManager, locationUpdates, locationUpdateError] observer, lifetime in
-            lifetime += locationUpdates.output.promoteError().observe(observer)
+            lifetime += locationUpdates.output
+                .take(first: 1)
+                .promoteError()
+                .observe(observer)
 
             lifetime += locationUpdateError.output.observeValues { error in
                 observer.send(error: error)


### PR DESCRIPTION
After the first weather update, the main UI would become unresponsive,
unable to scroll or refresh the latest weather update. This was caused
by the `LocationController.requestLocation()` producer sending a
location update but then never completing.